### PR TITLE
bug fix as mentioned on the phone

### DIFF
--- a/lib/Braintree.php
+++ b/lib/Braintree.php
@@ -53,6 +53,11 @@ abstract class Braintree
         }
     }
 
+    public function __isset($name)
+    {
+        return array_key_exists($name, $this->_attributes);
+    }
+
     public function _set($key, $value)
     {
         $this->_attributes[$key] = $value;


### PR DESCRIPTION
implement __isset on Braintree so that using isset() and empty() on properties of instances of Braintree\* will actually work
