### PR TITLE
Implemented a way to override the location of the CA file

### DIFF
--- a/lib/Braintree/Configuration.php
+++ b/lib/Braintree/Configuration.php
@@ -90,7 +90,7 @@ class Braintree_Configuration extends Braintree
                                     $value . '" is not a valid environment.');
         }
 
-        if (!isset(self::$_cache[$key])) {
+        if (!isset(self::$_cache[$key]) && self::$_cache[$key] !== null) {
              throw new Braintree_Exception_Configuration($key .
                                     ' is not a valid configuration setting.');
         }


### PR DESCRIPTION
I had a need to store the CA file somewhere that the configuration wasn't expecting, and couldn't see a way of overriding it.

This is a little bit of a workaround, since I was aware that there are parts of applications out there that might use the existing method and expect it to function a certain way when they pass a value in, i.e. that value wouldn't be the full path. 
