### PR TITLE
Fixes empty() on BrainTree inheritance objects

### DIFF
--- a/lib/Braintree/Instance.php
+++ b/lib/Braintree/Instance.php
@@ -46,6 +46,17 @@ abstract class Braintree_Instance
     }
 
     /**
+     * used by isset() and empty()
+     * @access public
+     * @param string $name property name
+     * @return boolean
+     */
+    public function __isset($name)
+    {
+        return array_key_exists($name, $this->_attributes);
+    }
+
+    /**
      * create a printable representation of the object as:
      * ClassName[property=value, property=value]
      * @return var
@@ -66,5 +77,5 @@ abstract class Braintree_Instance
     {
         $this->_attributes = $attributes;
     }
-    
+
 }


### PR DESCRIPTION
For example, empty() would incorrectly return true on:
$result->transaction->creditCardDetails->cardType
