### PR TITLE
Adds __isset magic method need for Twig use.

### DIFF
--- a/lib/Braintree/Error/Validation.php
+++ b/lib/Braintree/Error/Validation.php
@@ -61,4 +61,14 @@ class Braintree_Error_Validation
         $varName = "_$name";
         return isset($this->$varName) ? $this->$varName : null;
     }
+
+    /**
+     *
+     * @ignore
+     */
+    public function  __isset($name)
+    {
+        $varName = "_$name";
+        return isset($this->$varName) ? true : false;
+    }
 }

--- a/lib/Braintree/Result/CreditCardVerification.php
+++ b/lib/Braintree/Result/CreditCardVerification.php
@@ -75,6 +75,16 @@ class Braintree_Result_CreditCardVerification
     }
 
     /**
+     *
+     * @ignore
+     */
+    public function  __isset($name)
+    {
+        $varName = "_$name";
+        return isset($this->$varName) ? true : false;
+    }
+
+    /**
      * returns a string representation of the customer
      * @return string
      */


### PR DESCRIPTION
Was trying to use your lib in a Synfony2/Twig environment and ran into the problem of  not being able to use the message property of the Braintree_Error_Validation class.

Found this documentation http://twig.sensiolabs.org/doc/recipes.html#using-dynamic-object-properties that explains that to use the __get in a Twig environment you also need the __isset method.

Thanks.
