### PR TITLE
Fixes getting result value for custom fields.

### DIFF
--- a/lib/Braintree/Result/Error.php
+++ b/lib/Braintree/Result/Error.php
@@ -56,7 +56,11 @@ class Braintree_Result_Error extends Braintree
        foreach(array_slice($pieces, 0, -1) as $key) {
            $params = $params[Braintree_Util::delimiterToCamelCase($key)];
        }
-       $finalKey = Braintree_Util::delimiterToCamelCase(end($pieces));
+       if ($key != 'custom_fields') {
+           $finalKey = Braintree_Util::delimiterToCamelCase(end($pieces));
+       } else {
+           $finalKey = end($pieces);
+       }
        $fieldValue = isset($params[$finalKey]) ? $params[$finalKey] : null;
        return $fieldValue;
    }


### PR DESCRIPTION
While implementing a form that contains a custom form field, I found out that the 
result.valueForHtmlField(fieldName)
method would not return the value for custom fields.

So I propuse this small fix to the library.
Not sure if this is the correct of going about this, but it worked correctly for me.
