### PR TITLE
Fix class name references

### DIFF
--- a/lib/Braintree/CreditCard.php
+++ b/lib/Braintree/CreditCard.php
@@ -154,7 +154,7 @@ class Braintree_CreditCard extends Braintree
     {
         $response = Braintree_Http::post("/payment_methods/all/expired", array('search' => array('ids' => $ids)));
 
-        return braintree_util::extractattributeasarray(
+        return Braintree_Util::extractattributeasarray(
             $response['paymentMethods'],
             'creditCard'
         );

--- a/lib/Braintree/CreditCardVerification.php
+++ b/lib/Braintree/CreditCardVerification.php
@@ -14,9 +14,9 @@ class Braintree_CreditCardVerification extends Braintree_Result_CreditCardVerifi
             $criteria[$term->name] = $term->toparam();
         }
         $criteria["ids"] = Braintree_CreditCardVerificationSearch::ids()->in($ids)->toparam();
-        $response = braintree_http::post('/verifications/advanced_search', array('search' => $criteria));
+        $response = Braintree_Http::post('/verifications/advanced_search', array('search' => $criteria));
 
-        return braintree_util::extractattributeasarray(
+        return Braintree_Util::extractattributeasarray(
             $response['creditCardVerifications'],
             'verification'
         );
@@ -29,7 +29,7 @@ class Braintree_CreditCardVerification extends Braintree_Result_CreditCardVerifi
             $criteria[$term->name] = $term->toparam();
         }
 
-        $response = braintree_http::post('/verifications/advanced_search_ids', array('search' => $criteria));
+        $response = Braintree_Http::post('/verifications/advanced_search_ids', array('search' => $criteria));
         $pager = array(
             'className' => __CLASS__,
             'classMethod' => 'fetch',

--- a/lib/Braintree/Customer.php
+++ b/lib/Braintree/Customer.php
@@ -36,7 +36,7 @@ class Braintree_Customer extends Braintree
 {
     public static function all()
     {
-        $response = braintree_http::post('/customers/advanced_search_ids');
+        $response = Braintree_Http::post('/customers/advanced_search_ids');
         $pager = array(
             'className' => __CLASS__,
             'classMethod' => 'fetch',
@@ -53,9 +53,9 @@ class Braintree_Customer extends Braintree
             $criteria[$term->name] = $term->toparam();
         }
         $criteria["ids"] = Braintree_CustomerSearch::ids()->in($ids)->toparam();
-        $response = braintree_http::post('/customers/advanced_search', array('search' => $criteria));
+        $response = Braintree_Http::post('/customers/advanced_search', array('search' => $criteria));
 
-        return braintree_util::extractattributeasarray(
+        return Braintree_Util::extractattributeasarray(
             $response['customers'],
             'customer'
         );
@@ -302,7 +302,7 @@ class Braintree_Customer extends Braintree
             $criteria[$term->name] = $term->toparam();
         }
 
-        $response = braintree_http::post('/customers/advanced_search_ids', array('search' => $criteria));
+        $response = Braintree_Http::post('/customers/advanced_search_ids', array('search' => $criteria));
         $pager = array(
             'className' => __CLASS__,
             'classMethod' => 'fetch',

--- a/lib/Braintree/Subscription.php
+++ b/lib/Braintree/Subscription.php
@@ -58,7 +58,7 @@ class Braintree_Subscription extends Braintree
         }
 
 
-        $response = braintree_http::post('/subscriptions/advanced_search_ids', array('search' => $criteria));
+        $response = Braintree_Http::post('/subscriptions/advanced_search_ids', array('search' => $criteria));
         $pager = array(
             'className' => __CLASS__,
             'classMethod' => 'fetch',

--- a/lib/Braintree/Transaction.php
+++ b/lib/Braintree/Transaction.php
@@ -397,7 +397,7 @@ final class Braintree_Transaction extends Braintree
             $criteria[$term->name] = $term->toparam();
         }
 
-        $response = braintree_http::post('/transactions/advanced_search_ids', array('search' => $criteria));
+        $response = Braintree_Http::post('/transactions/advanced_search_ids', array('search' => $criteria));
         $pager = array(
             'className' => __CLASS__,
             'classMethod' => 'fetch',
@@ -414,9 +414,9 @@ final class Braintree_Transaction extends Braintree
             $criteria[$term->name] = $term->toparam();
         }
         $criteria["ids"] = Braintree_TransactionSearch::ids()->in($ids)->toparam();
-        $response = braintree_http::post('/transactions/advanced_search', array('search' => $criteria));
+        $response = Braintree_Http::post('/transactions/advanced_search', array('search' => $criteria));
 
-        return braintree_util::extractattributeasarray(
+        return Braintree_Util::extractattributeasarray(
             $response['creditCardTransactions'],
             'transaction'
         );


### PR DESCRIPTION
Autoloading can fail on case-sensitive filesystems if references to class names do not match the filename.
