### PR TITLE
Converted preg_replace() /e modifiers to preg_replace_callback()

### DIFF
--- a/lib/Braintree/Util.php
+++ b/lib/Braintree/Util.php
@@ -136,7 +136,15 @@ class Braintree_Util
      */
     public static function delimiterToCamelCase($string, $delimiter = '[\-\_]')
     {
-        return preg_replace('/' . $delimiter . '(\w)/e', 'strtoupper("$1")',$string);
+        // php doesn't garbage collect functions created by create_function()
+        // so use a static variable to avoid adding a new function to memory
+        // every time this function is called.
+        static $callback = null;
+        if ($callback === null) {
+            $callback = create_function('$matches', 'return strtoupper($matches[1]);');
+        }
+
+        return preg_replace_callback('/' . $delimiter . '(\w)/', $callback, $string);
     }
 
     /**
@@ -161,7 +169,15 @@ class Braintree_Util
      */
     public static function camelCaseToDelimiter($string, $delimiter = '-')
     {
-        return preg_replace('/([A-Z])/e', '"' . $delimiter . '" . strtolower("$1")', $string);
+        // php doesn't garbage collect functions created by create_function()
+        // so use a static variable to avoid adding a new function to memory
+        // every time this function is called.
+        static $callbacks = array();
+        if (!isset($callbacks[$delimiter])) {
+            $callbacks[$delimiter] = create_function('$matches', "return '$delimiter' . strtolower(\$matches[1]);");
+        }
+
+        return preg_replace_callback('/([A-Z])/', $callbacks[$delimiter], $string);
     }
 
     /**


### PR DESCRIPTION
http://php.net/manual/en/migration55.deprecated.php
preg_replace() \e is depricated in PHP5.5 and throws a warning
