### PR TITLE
replaced callback in camelCaseToDelimiter with strtolower

### DIFF
--- a/lib/Braintree/Util.php
+++ b/lib/Braintree/Util.php
@@ -171,15 +171,7 @@ class Braintree_Util
      */
     public static function camelCaseToDelimiter($string, $delimiter = '-')
     {
-        // php doesn't garbage collect functions created by create_function()
-        // so use a static variable to avoid adding a new function to memory
-        // every time this function is called.
-        static $callbacks = array();
-        if (!isset($callbacks[$delimiter])) {
-            $callbacks[$delimiter] = create_function('$matches', "return '$delimiter' . strtolower(\$matches[1]);");
-        }
-
-        return preg_replace_callback('/([A-Z])/', $callbacks[$delimiter], $string);
+        return strtolower(preg_replace('/([A-Z])/', '-\1', $string));
     }
 
     /**

--- a/lib/Braintree/Util.php
+++ b/lib/Braintree/Util.php
@@ -166,12 +166,13 @@ class Braintree_Util
      * find capitals and convert to delimiter + lowercase
      *
      * @access public
-     * @param var $string
+     * @param string $string
+     * @param string $delimiter (optional, defaults to -)
      * @return var modified string
      */
     public static function camelCaseToDelimiter($string, $delimiter = '-')
     {
-        return strtolower(preg_replace('/([A-Z])/', '-\1', $string));
+        return strtolower(preg_replace('/([A-Z])/', "$delimiter\\1", $string));
     }
 
     /**


### PR DESCRIPTION
Hi!

The `create_function` version of `camelCaseToDelimiter` can be used to inject arbitrary code via the `$delimiter` parameter (set it to `' . printf("hello") . '` for example). I'm not sure if you expose that parameter to the outside world somewhere, but I think it's still better to not have that in the code. :)