### PR TITLE
[Factory] Fixed factory on classes that extend Modification

### DIFF
--- a/lib/Braintree/AddOn.php
+++ b/lib/Braintree/AddOn.php
@@ -12,4 +12,11 @@ class Braintree_AddOn extends Braintree_Modification
             'addOn'
         );
     }
+
+    public static function factory($attributes)
+    {
+        $instance = new self();
+        $instance->_initialize($attributes);
+        return $instance;
+    }
 }

--- a/lib/Braintree/Discount.php
+++ b/lib/Braintree/Discount.php
@@ -12,4 +12,11 @@ class Braintree_Discount extends Braintree_Modification
             'discount'
         );
     }
+
+    public static function factory($attributes)
+    {
+        $instance = new self();
+        $instance->_initialize($attributes);
+        return $instance;
+    }
 }

--- a/tests/unit/AddOnTest.php
+++ b/tests/unit/AddOnTest.php
@@ -1,0 +1,12 @@
+<?php
+require_once realpath(dirname(__FILE__)) . '/../TestHelper.php';
+
+class Braintree_AddOnTest extends PHPUnit_Framework_TestCase
+{
+    public function testFactory()
+    {
+        $addOn = \Braintree_AddOn::factory(array());
+
+        $this->assertInstanceOf('Braintree_AddOn', $addOn);
+    }
+}

--- a/tests/unit/DiscountTest.php
+++ b/tests/unit/DiscountTest.php
@@ -1,0 +1,12 @@
+<?php
+require_once realpath(dirname(__FILE__)) . '/../TestHelper.php';
+
+class Braintree_DiscountTest extends PHPUnit_Framework_TestCase
+{
+    public function testFactory()
+    {
+        $discount = \Braintree_Discount::factory(array());
+
+        $this->assertInstanceOf('Braintree_Discount', $discount);
+    }
+}


### PR DESCRIPTION
Hi, I found an issue on the factory method of the Modifcation class, because I invoke the static function `factory` on Discount class, I have back an instance of Modification and not an instance of Discount.
