### PR TITLE
Multiple PHPDoc fixes and improvements

### DIFF
--- a/lib/Braintree/Address.php
+++ b/lib/Braintree/Address.php
@@ -39,7 +39,7 @@ class Braintree_Address extends Braintree
      *
      * @access public
      * @param  array  $attribs
-     * @return object Result, either Successful or Error
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function create($attribs)
     {
@@ -62,8 +62,8 @@ class Braintree_Address extends Braintree
      *
      * @access public
      * @param  array $attribs
-     * @return object
-     * @throws Braintree_Exception_ValidationError
+     * @return self
+     * @throws Braintree_Exception_ValidationsFailed
      */
     public static function createNoValidate($attribs)
     {
@@ -77,6 +77,7 @@ class Braintree_Address extends Braintree
      *
      * @param mixed $customerOrId
      * @param string $addressId
+     * @return Braintree_Result_Successful
      */
     public static function delete($customerOrId = null, $addressId = null)
     {
@@ -99,7 +100,7 @@ class Braintree_Address extends Braintree
      * @access public
      * @param mixed $customerOrId
      * @param string $addressId
-     * @return object Braintree_Address
+     * @return self
      * @throws Braintree_Exception_NotFound
      */
     public static function find($customerOrId, $addressId)
@@ -148,7 +149,7 @@ class Braintree_Address extends Braintree
      * @param array $attributes
      * @param mixed $customerOrId (only used in static call)
      * @param string $addressId (only used in static call)
-     * @return object Braintree_Result_Successful or Braintree_Result_Error
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function update($customerOrId, $addressId, $attributes)
     {
@@ -173,9 +174,10 @@ class Braintree_Address extends Braintree
      * customerOrId & addressId are not sent in object context.
      *
      * @access public
-     * @param array $transactionAttribs
-     * @param string $customerId
-     * @return object Braintree_Transaction
+     * @param array $attributes
+     * @param mixed $customerOrId (only used in static call)
+     * @param string $addressId (only used in static call)
+     * @return self
      * @throws Braintree_Exception_ValidationsFailed
      * @see Braintree_Address::update()
      */
@@ -213,7 +215,7 @@ class Braintree_Address extends Braintree
      * create a printable representation of the object as:
      * ClassName[property=value, property=value]
      * @ignore
-     * @return var
+     * @return string
      */
     public function  __toString()
     {
@@ -227,7 +229,7 @@ class Braintree_Address extends Braintree
      * @ignore
      * @access protected
      * @param array $addressAttribs array of address data
-     * @return none
+     * @return void
      */
     protected function _initialize($addressAttribs)
     {
@@ -296,7 +298,7 @@ class Braintree_Address extends Braintree
      * @ignore
      * @param string $url
      * @param array $params
-     * @return mixed
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     private static function _doCreate($url, $params)
     {
@@ -316,7 +318,7 @@ class Braintree_Address extends Braintree
      *
      * @ignore
      * @param array $response gateway response values
-     * @return object Result_Successful or Result_Error
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      * @throws Braintree_Exception_Unexpected
      */
     private static function _verifyGatewayResponse($response)
@@ -340,7 +342,8 @@ class Braintree_Address extends Braintree
      *  factory method: returns an instance of Braintree_Address
      *  to the requesting method, with populated properties
      * @ignore
-     * @return object instance of Braintree_Address
+     * @param array $attributes array of address data
+     * @return self instance of Braintree_Address
      */
     public static function factory($attributes)
     {

--- a/lib/Braintree/CreditCard.php
+++ b/lib/Braintree/CreditCard.php
@@ -94,8 +94,8 @@ class Braintree_CreditCard extends Braintree
      *
      * @access public
      * @param array $attribs
-     * @return object
-     * @throws Braintree_Exception_ValidationError
+     * @return self
+     * @throws Braintree_Exception_ValidationsFailed
      */
     public static function createNoValidate($attribs)
     {
@@ -106,8 +106,8 @@ class Braintree_CreditCard extends Braintree
      * create a customer from a TransparentRedirect operation
      *
      * @access public
-     * @param array $attribs
-     * @return object
+     * @param string $queryString
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function createFromTransparentRedirect($queryString)
     {
@@ -136,7 +136,7 @@ class Braintree_CreditCard extends Braintree
 
     /**
      * returns a ResourceCollection of expired credit cards
-     * @return object ResourceCollection
+     * @return Braintree_ResourceCollection
      */
     public static function expired()
     {
@@ -162,7 +162,7 @@ class Braintree_CreditCard extends Braintree
     /**
      * returns a ResourceCollection of credit cards expiring between start/end
      *
-     * @return object ResourceCollection
+     * @return Braintree_ResourceCollection
      */
     public static function expiringBetween($startDate, $endDate)
     {
@@ -193,7 +193,7 @@ class Braintree_CreditCard extends Braintree
      *
      * @access public
      * @param string $token credit card unique id
-     * @return object Braintree_CreditCard
+     * @return self
      * @throws Braintree_Exception_NotFound
      */
     public static function find($token)
@@ -214,8 +214,9 @@ class Braintree_CreditCard extends Braintree
      * create a credit on the card for the passed transaction
      *
      * @access public
-     * @param array $attribs
-     * @return object Braintree_Result_Successful or Braintree_Result_Error
+    * @param string $token
+    * @param array $transactionAttribs
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function credit($token, $transactionAttribs)
     {
@@ -234,9 +235,10 @@ class Braintree_CreditCard extends Braintree
      * returns a Braintree_Transaction object on success
      *
      * @access public
-     * @param array $attribs
-     * @return object Braintree_Transaction
-     * @throws Braintree_Exception_ValidationError
+     * @param string $token
+     * @param array $transactionAttribs
+     * @return Braintree_Transaction
+     * @throws Braintree_Exception_ValidationsFailed
      */
     public static function creditNoValidate($token, $transactionAttribs)
     {
@@ -249,7 +251,7 @@ class Braintree_CreditCard extends Braintree
      *
      * @param string $token
      * @param array $transactionAttribs
-     * @return object Braintree_Result_Successful or Braintree_Result_Error
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      * @see Braintree_Transaction::sale()
      */
     public static function sale($token, $transactionAttribs)
@@ -271,7 +273,7 @@ class Braintree_CreditCard extends Braintree
      * @access public
      * @param array $transactionAttribs
      * @param string $token
-     * @return object Braintree_Transaction
+     * @return Braintree_Transaction
      * @throws Braintree_Exception_ValidationsFailed
      * @see Braintree_Transaction::sale()
      */
@@ -290,7 +292,7 @@ class Braintree_CreditCard extends Braintree
      * @access public
      * @param array $attributes
      * @param string $token (optional)
-     * @return object Braintree_Result_Successful or Braintree_Result_Error
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function update($token, $attributes)
     {
@@ -309,7 +311,7 @@ class Braintree_CreditCard extends Braintree
      * @access public
      * @param array $attributes
      * @param string $token
-     * @return object Braintree_CreditCard
+     * @return self
      * @throws Braintree_Exception_ValidationsFailed
      */
     public static function updateNoValidate($token, $attributes)
@@ -334,8 +336,8 @@ class Braintree_CreditCard extends Braintree
      * update a customer from a TransparentRedirect operation
      *
      * @access public
-     * @param array $attribs
-     * @return object
+     * @param string $queryString
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function updateFromTransparentRedirect($queryString)
     {
@@ -393,7 +395,7 @@ class Braintree_CreditCard extends Braintree
      *
      * @access protected
      * @param array $creditCardAttribs array of creditcard data
-     * @return none
+     * @return void
      */
     protected function _initialize($creditCardAttribs)
     {
@@ -497,7 +499,7 @@ class Braintree_CreditCard extends Braintree
      * @ignore
      * @param string $url
      * @param array $params
-     * @return mixed
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function _doCreate($url, $params)
     {
@@ -541,9 +543,10 @@ class Braintree_CreditCard extends Braintree
      * sends the update request to the gateway
      *
      * @ignore
+     * @param string $httpVerb
      * @param string $url
      * @param array $params
-     * @return mixed
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     private static function _doUpdate($httpVerb, $url, $params)
     {
@@ -561,7 +564,7 @@ class Braintree_CreditCard extends Braintree
      *
      * @ignore
      * @param array $response gateway response values
-     * @return object Result_Successful or Result_Error
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      * @throws Braintree_Exception_Unexpected
      */
     private static function _verifyGatewayResponse($response)
@@ -585,7 +588,8 @@ class Braintree_CreditCard extends Braintree
      *  to the requesting method, with populated properties
      *
      * @ignore
-     * @return object instance of Braintree_CreditCard
+     * @param array $attributes array of creditcard data
+     * @return self instance of Braintree_CreditCard
      */
     public static function factory($attributes)
     {

--- a/lib/Braintree/Customer.php
+++ b/lib/Braintree/Customer.php
@@ -84,7 +84,7 @@ class Braintree_Customer extends Braintree
      *
      * @access public
      * @param array $attribs
-     * @return object Result, either Successful or Error
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function create($attribs = array())
     {
@@ -98,8 +98,8 @@ class Braintree_Customer extends Braintree
      *
      * @access public
      * @param array $attribs
-     * @return object
-     * @throws Braintree_Exception_ValidationError
+     * @return self
+     * @throws Braintree_Exception_ValidationsFailed
      */
     public static function createNoValidate($attribs = array())
     {
@@ -110,8 +110,8 @@ class Braintree_Customer extends Braintree
      * create a customer from a TransparentRedirect operation
      *
      * @access public
-     * @param array $attribs
-     * @return object
+     * @param string $queryString
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function createFromTransparentRedirect($queryString)
     {
@@ -187,8 +187,8 @@ class Braintree_Customer extends Braintree
      * find a customer by id
      *
      * @access public
-     * @param string id customer Id
-     * @return object Braintree_Customer
+     * @param string $id customer Id
+     * @return self
      * @throws Braintree_Exception_NotFound
      */
     public static function find($id)
@@ -209,8 +209,9 @@ class Braintree_Customer extends Braintree
      * credit a customer for the passed transaction
      *
      * @access public
-     * @param array $attribs
-     * @return object Braintree_Result_Successful or Braintree_Result_Error
+     * @param string $customerId
+     * @param array $transactionAttribs
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function credit($customerId, $transactionAttribs)
     {
@@ -228,9 +229,10 @@ class Braintree_Customer extends Braintree
      * returns a Braintree_Transaction object on success
      *
      * @access public
-     * @param array $attribs
-     * @return object Braintree_Transaction
-     * @throws Braintree_Exception_ValidationError
+     * @param string $customerId
+     * @param array $transactionAttribs
+     * @return Braintree_Transaction
+     * @throws Braintree_Exception_ValidationsFailed
      */
     public static function creditNoValidate($customerId, $transactionAttribs)
     {
@@ -242,6 +244,7 @@ class Braintree_Customer extends Braintree
      * delete a customer by id
      *
      * @param string $customerId
+     * @return Braintree_Result_Successful
      */
     public static function delete($customerId)
     {
@@ -255,7 +258,7 @@ class Braintree_Customer extends Braintree
      *
      * @param string $customerId
      * @param array $transactionAttribs
-     * @return object Braintree_Result_Successful or Braintree_Result_Error
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      * @see Braintree_Transaction::sale()
      */
     public static function sale($customerId, $transactionAttribs)
@@ -275,7 +278,7 @@ class Braintree_Customer extends Braintree
      * @access public
      * @param string $customerId
      * @param array $transactionAttribs
-     * @return object Braintree_Transaction
+     * @return Braintree_Transaction
      * @throws Braintree_Exception_ValidationsFailed
      * @see Braintree_Transaction::sale()
      */
@@ -293,8 +296,7 @@ class Braintree_Customer extends Braintree
      * For more detailed information and examples, see {@link http://www.braintreepayments.com/gateway/customer-api#searching http://www.braintreepaymentsolutions.com/gateway/customer-api}
      *
      * @param mixed $query search query
-     * @param array $options options such as page number
-     * @return object Braintree_ResourceCollection
+     * @return Braintree_ResourceCollection
      * @throws InvalidArgumentException
      */
     public static function search($query)
@@ -323,7 +325,7 @@ class Braintree_Customer extends Braintree
      * @access public
      * @param array $attributes
      * @param string $customerId (optional)
-     * @return object Braintree_Result_Successful or Braintree_Result_Error
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function update($customerId, $attributes)
     {
@@ -346,7 +348,7 @@ class Braintree_Customer extends Braintree
      * @access public
      * @param array $attributes
      * @param string $customerId
-     * @return object Braintree_Customer
+     * @return self
      * @throws Braintree_Exception_ValidationsFailed
      */
     public static function updateNoValidate($customerId, $attributes)
@@ -371,8 +373,8 @@ class Braintree_Customer extends Braintree
      * update a customer from a TransparentRedirect operation
      *
      * @access public
-     * @param array $attribs
-     * @return object
+     * @param string $queryString
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function updateFromTransparentRedirect($queryString)
     {
@@ -395,7 +397,7 @@ class Braintree_Customer extends Braintree
      * @ignore
      * @access protected
      * @param array $customerAttribs array of customer data
-     * @return none
+     * @return void
      */
     protected function _initialize($customerAttribs)
     {
@@ -472,7 +474,7 @@ class Braintree_Customer extends Braintree
      * @ignore
      * @param string $url
      * @param array $params
-     * @return mixed
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function _doCreate($url, $params)
     {
@@ -484,7 +486,7 @@ class Braintree_Customer extends Braintree
     /**
      * verifies that a valid customer id is being used
      * @ignore
-     * @param string customer id
+     * @param string $id customer id
      * @throws InvalidArgumentException
      */
     private static function _validateId($id = null) {
@@ -507,9 +509,10 @@ class Braintree_Customer extends Braintree
      * sends the update request to the gateway
      *
      * @ignore
+     * @param string $httpVerb
      * @param string $url
      * @param array $params
-     * @return mixed
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     private static function _doUpdate($httpVerb, $url, $params)
     {
@@ -528,7 +531,7 @@ class Braintree_Customer extends Braintree
      *
      * @ignore
      * @param array $response gateway response values
-     * @return object Result_Successful or Result_Error
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      * @throws Braintree_Exception_Unexpected
      */
     private static function _verifyGatewayResponse($response)
@@ -552,7 +555,8 @@ class Braintree_Customer extends Braintree
      *  to the requesting method, with populated properties
      *
      * @ignore
-     * @return object instance of Braintree_Customer
+     * @param array $attributes array of customer data
+     * @return self instance of Braintree_Customer
      */
     public static function factory($attributes)
     {

--- a/lib/Braintree/Error/ErrorCollection.php
+++ b/lib/Braintree/Error/ErrorCollection.php
@@ -20,7 +20,7 @@
  * @category   Errors
  * @copyright  2010 Braintree Payment Solutions
  *
- * @property-read object $errors
+ * @property-read Braintree_Error_ValidationErrorCollection $errors
  */
 class Braintree_Error_ErrorCollection
 {

--- a/lib/Braintree/Error/Validation.php
+++ b/lib/Braintree/Error/Validation.php
@@ -42,7 +42,7 @@ class Braintree_Error_Validation
      * @ignore
      * @access protected
      * @param array $attributes array of properties to set - single level
-     * @return none
+     * @return void
      */
     private function _initializeFromArray($attributes)
     {

--- a/lib/Braintree/Instance.php
+++ b/lib/Braintree/Instance.php
@@ -19,7 +19,7 @@ abstract class Braintree_Instance
 {
     /**
      *
-     * @param array $aAttribs
+     * @param array $attributes
      */
     public function  __construct($attributes)
     {
@@ -32,7 +32,7 @@ abstract class Braintree_Instance
     /**
      * returns private/nonexistent instance properties
      * @access public
-     * @param var $name property name
+     * @param string $name property name
      * @return mixed contents of instance properties
      */
     public function __get($name)
@@ -71,7 +71,7 @@ abstract class Braintree_Instance
      * @ignore
      * @access protected
      * @param <type> $aAttribs array of properties to set - single level
-     * @return none
+     * @return void
      */
     private function _initializeFromArray($attributes)
     {

--- a/lib/Braintree/ResourceCollection.php
+++ b/lib/Braintree/ResourceCollection.php
@@ -38,8 +38,8 @@ class Braintree_ResourceCollection implements Iterator
      *
      * expects an array of attributes with literal keys
      *
-     * @param array $attributes
-     * @param array $pagerAttribs
+     * @param array $response
+     * @param array $pager
      */
     public function  __construct($response, $pager)
     {
@@ -128,7 +128,7 @@ class Braintree_ResourceCollection implements Iterator
     /**
      * requests the next page of results for the collection
      *
-     * @return none
+     * @return void
      */
     private function _getPage($ids)
     {

--- a/lib/Braintree/Result/CreditCardVerification.php
+++ b/lib/Braintree/Result/CreditCardVerification.php
@@ -53,7 +53,7 @@ class Braintree_Result_CreditCardVerification
      * @ignore
      * @access protected
      * @param <type> $aAttribs array of properties to set - single level
-     * @return none
+     * @return void
      */
     private function _initializeFromArray($attributes)
     {

--- a/lib/Braintree/Result/Error.php
+++ b/lib/Braintree/Result/Error.php
@@ -30,8 +30,8 @@
  * @copyright  2010 Braintree Payment Solutions
  *
  * @property-read array $params original passed params
- * @property-read object $errors Braintree_Error_ErrorCollection
- * @property-read object $creditCardVerification credit card verification data
+ * @property-read Braintree_Error_ErrorCollection $errors Braintree_Error_ErrorCollection
+ * @property-read Braintree_Result_CreditCardVerification $creditCardVerification credit card verification data
  */
 class Braintree_Result_Error extends Braintree
 {

--- a/lib/Braintree/Result/Successful.php
+++ b/lib/Braintree/Result/Successful.php
@@ -46,7 +46,7 @@ class Braintree_Result_Successful extends Braintree_Instance
 
     /**
      * @ignore
-     * @param string $classToReturn name of class to instantiate
+     * @param string $objToReturn name of class to instantiate
      */
     public function __construct($objToReturn = null)
     {

--- a/lib/Braintree/Transaction.php
+++ b/lib/Braintree/Transaction.php
@@ -153,18 +153,18 @@
  * @property-read string $cvvResponseCode
  * @property-read string $id transaction id
  * @property-read string $amount transaction amount
- * @property-read object $billingDetails transaction billing address
+ * @property-read Braintree_Transaction_AddressDetails $billingDetails transaction billing address
  * @property-read string $createdAt transaction created timestamp
- * @property-read object $creditCardDetails transaction credit card info
- * @property-read object $customerDetails transaction customer info
+ * @property-read Braintree_Transaction_CreditCardDetails $creditCardDetails transaction credit card info
+ * @property-read Braintree_Transaction_CustomerDetails $customerDetails transaction customer info
  * @property-read array  $customFields custom fields passed with the request
  * @property-read string $processorResponseCode gateway response code
- * @property-read object $shippingDetails transaction shipping address
+ * @property-read Braintree_Transaction_AddressDetails $shippingDetails transaction shipping address
  * @property-read string $status transaction status
  * @property-read array  $statusHistory array of StatusDetails objects
  * @property-read string $type transaction type
  * @property-read string $updatedAt transaction updated timestamp
- * @property-read object $disbursementDetails populated when transaction is disbursed
+ * @property-read Braintree_DisbursementDetails $disbursementDetails populated when transaction is disbursed
  *
  */
 
@@ -220,7 +220,7 @@ final class Braintree_Transaction extends Braintree
      * @ignore
      * @access public
      * @param array $attribs
-     * @return object
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     private static function create($attribs)
     {
@@ -233,8 +233,8 @@ final class Braintree_Transaction extends Braintree
      * @ignore
      * @access public
      * @param array $attribs
-     * @return object
-     * @throws Braintree_Exception_ValidationError
+     * @return self
+     * @throws Braintree_Exception_ValidationsFailed
      */
     private static function createNoValidate($attribs)
     {
@@ -244,8 +244,8 @@ final class Braintree_Transaction extends Braintree
     /**
      *
      * @access public
-     * @param array $attribs
-     * @return object
+     * @param array $queryString
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function createFromTransparentRedirect($queryString)
     {
@@ -328,7 +328,7 @@ final class Braintree_Transaction extends Braintree
      *
      * @access public
      * @param array $attribs
-     * @return object
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function credit($attribs)
     {
@@ -339,8 +339,8 @@ final class Braintree_Transaction extends Braintree
      *
      * @access public
      * @param array $attribs
-     * @return object
-     * @throws Braintree_Exception_ValidationError
+     * @return self
+     * @throws Braintree_Exception_ValidationsFailed
      */
     public static function creditNoValidate($attribs)
     {
@@ -369,7 +369,7 @@ final class Braintree_Transaction extends Braintree
     /**
      * new sale
      * @param array $attribs
-     * @return array
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function sale($attribs)
     {
@@ -380,7 +380,7 @@ final class Braintree_Transaction extends Braintree
      * roughly equivalent to the ruby bang method
      * @access public
      * @param array $attribs
-     * @return array
+     * @return self
      * @throws Braintree_Exception_ValidationsFailed
      */
     public static function saleNoValidate($attribs)
@@ -397,9 +397,8 @@ final class Braintree_Transaction extends Braintree
      * For more detailed information and examples, see {@link http://www.braintreepayments.com/gateway/transaction-api#searching http://www.braintreepaymentsolutions.com/gateway/transaction-api}
      *
      * @param mixed $query search query
-     * @param array $options options such as page number
-     * @return object Braintree_ResourceCollection
-     * @throws InvalidArgumentException
+     * @return Braintree_ResourceCollection
+     * @throws Braintree_Exception_DownForMaintenance
      */
     public static function search($query)
     {
@@ -440,8 +439,8 @@ final class Braintree_Transaction extends Braintree
     /**
      * void a transaction by id
      *
-     * @param string $id transaction id
-     * @return object Braintree_Result_Successful|Braintree_Result_Error
+     * @param string $transactionId transaction id
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function void($transactionId)
     {
@@ -516,7 +515,7 @@ final class Braintree_Transaction extends Braintree
      * @ignore
      * @access protected
      * @param array $transactionAttribs array of transaction data
-     * @return none
+     * @return void
      */
     protected function _initialize($transactionAttribs)
     {
@@ -664,9 +663,9 @@ final class Braintree_Transaction extends Braintree
      * sends the create request to the gateway
      *
      * @ignore
-     * @param var $url
+     * @param string $url
      * @param array $params
-     * @return mixed
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      */
     public static function _doCreate($url, $params)
     {
@@ -678,7 +677,7 @@ final class Braintree_Transaction extends Braintree
     /**
      * verifies that a valid transaction id is being used
      * @ignore
-     * @param string transaction id
+     * @param string $id transaction id
      * @throws InvalidArgumentException
      */
     private static function _validateId($id = null) {
@@ -707,7 +706,7 @@ final class Braintree_Transaction extends Braintree
      *
      * @ignore
      * @param array $response gateway response values
-     * @return object Result_Successful or Result_Error
+     * @return Braintree_Result_Successful|Braintree_Result_Error
      * @throws Braintree_Exception_Unexpected
      */
     private static function _verifyGatewayResponse($response)
@@ -731,7 +730,8 @@ final class Braintree_Transaction extends Braintree
      *  to the requesting method, with populated properties
      *
      * @ignore
-     * @return object instance of Braintree_Transaction
+     * @param array $attributes array of transaction data
+     * @return self instance of Braintree_Transaction
      */
     public static function factory($attributes)
     {

--- a/lib/Braintree/Util.php
+++ b/lib/Braintree/Util.php
@@ -49,6 +49,7 @@ class Braintree_Util
     /**
      * throws an exception based on the type of error
      * @param string $statusCode HTTP status code to throw exception from
+     * @param null|string $message
      * @throws Braintree_Exception multiple types depending on the error
      *
      */
@@ -134,6 +135,7 @@ class Braintree_Util
      *
      * @access public
      * @param string $string
+     * @param string $delimiter
      * @return string modified string
      */
     public static function delimiterToCamelCase($string, $delimiter = '[\-\_]')
@@ -166,8 +168,9 @@ class Braintree_Util
      * find capitals and convert to delimiter + lowercase
      *
      * @access public
-     * @param var $string
-     * @return var modified string
+     * @param string $string
+     * @param string $delimiter
+     * @return string modified string
      */
     public static function camelCaseToDelimiter($string, $delimiter = '-')
     {
@@ -187,6 +190,7 @@ class Braintree_Util
      * @param array $array associative array to implode
      * @param string $separator (optional, defaults to =)
      * @param string $glue (optional, defaults to ', ')
+     * @return bool
      */
     public static function implodeAssociativeArray($array, $separator = '=', $glue = ', ')
     {

--- a/lib/Braintree/Xml/Generator.php
+++ b/lib/Braintree/Xml/Generator.php
@@ -17,7 +17,7 @@ class Braintree_Xml_Generator
      * arrays passed to this method should have a single root element
      * with an array as its value
      * @param array $aData the array of data
-     * @return var XML string
+     * @return string XML string
      */
     public static function arrayToXml($aData)
     {
@@ -50,9 +50,9 @@ class Braintree_Xml_Generator
      *
      * @access protected
      * @static
-     * @param object $writer XMLWriter object
+     * @param XMLWriter $writer XMLWriter object
      * @param array $aData contains attributes and values
-     * @return none
+     * @return void
      */
     private static function _createElementsFromArray(&$writer, $aData)
     {
@@ -119,8 +119,8 @@ class Braintree_Xml_Generator
     /**
      * converts datetime back to xml schema format
      * @access protected
-     * @param object $dateTime
-     * @return var XML schema formatted timestamp
+     * @param DateTime $dateTime
+     * @return string XML schema formatted timestamp
      */
     private static function _dateTimeToXmlTimestamp($dateTime)
     {

--- a/lib/Braintree/Xml/Parser.php
+++ b/lib/Braintree/Xml/Parser.php
@@ -43,7 +43,7 @@ class Braintree_Xml_Parser
      * processes SimpleXMLIterator objects recursively
      *
      * @access protected
-     * @param object $iterator
+     * @param Iterator $iterator
      * @return array xml converted to array
      */
     private static function _iteratorToArray($iterator)
@@ -121,7 +121,7 @@ class Braintree_Xml_Parser
 
     /**
      * typecast xml value based on attributes
-     * @param object $valueObj SimpleXMLElement
+     * @param SimpleXMLElement $valueObj SimpleXMLElement
      * @return mixed value for placing into array
      */
     private static function _typecastXmlValue($valueObj)


### PR DESCRIPTION
This PR improves IDE autodetection and autocompletion of types making it easy error detection while writting the code.

Changes:
 * replace almost all 'object' types with specific class types used
 * fix wrong attribute names
 * replace 'none' type with ' void' (the first one is not a valid phpdoc type)
 * replace some non exist exception classes with the correct one

Also add many missing params declaration.


No runtime code has been modified. Just PHPDoc annotations