### PR TITLE
Missing property causes notice errors

### DIFF
--- a/lib/Braintree/Instance.php
+++ b/lib/Braintree/Instance.php
@@ -17,6 +17,8 @@
  */
 abstract class Braintree_Instance
 {
+    private $_attributes = array();
+
     /**
      *
      * @param array $aAttribs


### PR DESCRIPTION
This is currently causing notice errors to be triggered when error reporting is set to E_ALL.

FYI, I'm using PHP 5.5
