### PR TITLE
Feature psr0 loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following PHP extensions are required:
 ```php
 <?php
 
-require_once 'PATH_TO_BRAINTREE/lib/Braintree.php';
+require_once 'PATH_TO_BRAINTREE/lib/loader.php';
 
 Braintree_Configuration::environment('sandbox');
 Braintree_Configuration::merchantId('your_merchant_id');

--- a/lib/Braintree.php
+++ b/lib/Braintree.php
@@ -85,3 +85,10 @@ abstract class Braintree
     }
 }
 
+/* This is a hack to detect if an autoloader is currently available.
+ * If we can't load this little class, this means we need to setup our
+ * own PSR-0 autoloader. */
+if (!class_exists ('Braintree_Version')) {
+    require_once (dirname (__FILE__) . 'loader.php');
+}
+

--- a/lib/Braintree.php
+++ b/lib/Braintree.php
@@ -8,8 +8,6 @@
  */
 
 
-set_include_path(get_include_path() . PATH_SEPARATOR . realpath(dirname(__FILE__)));
-
 /**
  * Braintree PHP Library
  *
@@ -86,99 +84,4 @@ abstract class Braintree
         }
     }
 }
-require_once('Braintree/Modification.php');
-require_once('Braintree/Instance.php');
 
-require_once('Braintree/Address.php');
-require_once('Braintree/AddOn.php');
-require_once('Braintree/ClientToken.php');
-require_once('Braintree/Collection.php');
-require_once('Braintree/Configuration.php');
-require_once('Braintree/CreditCard.php');
-require_once('Braintree/Customer.php');
-require_once('Braintree/CustomerSearch.php');
-require_once('Braintree/DisbursementDetails.php');
-require_once('Braintree/Dispute.php');
-require_once('Braintree/Descriptor.php');
-require_once('Braintree/Digest.php');
-require_once('Braintree/Discount.php');
-require_once('Braintree/IsNode.php');
-require_once('Braintree/EqualityNode.php');
-require_once('Braintree/Exception.php');
-require_once('Braintree/Http.php');
-require_once('Braintree/KeyValueNode.php');
-require_once('Braintree/MerchantAccount.php');
-require_once('Braintree/MerchantAccount/BusinessDetails.php');
-require_once('Braintree/MerchantAccount/FundingDetails.php');
-require_once('Braintree/MerchantAccount/IndividualDetails.php');
-require_once('Braintree/MerchantAccount/AddressDetails.php');
-require_once('Braintree/MultipleValueNode.php');
-require_once('Braintree/MultipleValueOrTextNode.php');
-require_once('Braintree/PartialMatchNode.php');
-require_once('Braintree/Plan.php');
-require_once('Braintree/RangeNode.php');
-require_once('Braintree/ResourceCollection.php');
-require_once('Braintree/SettlementBatchSummary.php');
-require_once('Braintree/SignatureService.php');
-require_once('Braintree/Subscription.php');
-require_once('Braintree/SubscriptionSearch.php');
-require_once('Braintree/TextNode.php');
-require_once('Braintree/Transaction.php');
-require_once('Braintree/Disbursement.php');
-require_once('Braintree/TransactionSearch.php');
-require_once('Braintree/TransparentRedirect.php');
-require_once('Braintree/Util.php');
-require_once('Braintree/Version.php');
-require_once('Braintree/Xml.php');
-require_once('Braintree/Error/Codes.php');
-require_once('Braintree/Error/ErrorCollection.php');
-require_once('Braintree/Error/Validation.php');
-require_once('Braintree/Error/ValidationErrorCollection.php');
-require_once('Braintree/Exception/Authentication.php');
-require_once('Braintree/Exception/Authorization.php');
-require_once('Braintree/Exception/Configuration.php');
-require_once('Braintree/Exception/DownForMaintenance.php');
-require_once('Braintree/Exception/ForgedQueryString.php');
-require_once('Braintree/Exception/InvalidSignature.php');
-require_once('Braintree/Exception/NotFound.php');
-require_once('Braintree/Exception/ServerError.php');
-require_once('Braintree/Exception/SSLCertificate.php');
-require_once('Braintree/Exception/SSLCaFileNotFound.php');
-require_once('Braintree/Exception/Unexpected.php');
-require_once('Braintree/Exception/UpgradeRequired.php');
-require_once('Braintree/Exception/ValidationsFailed.php');
-require_once('Braintree/Result/CreditCardVerification.php');
-require_once('Braintree/Result/Error.php');
-require_once('Braintree/Result/Successful.php');
-require_once('Braintree/Test/CreditCardNumbers.php');
-require_once('Braintree/Test/MerchantAccount.php');
-require_once('Braintree/Test/TransactionAmounts.php');
-require_once('Braintree/Test/VenmoSdk.php');
-require_once('Braintree/Transaction/AddressDetails.php');
-require_once('Braintree/Transaction/CreditCardDetails.php');
-require_once('Braintree/Transaction/CustomerDetails.php');
-require_once('Braintree/Transaction/StatusDetails.php');
-require_once('Braintree/Transaction/SubscriptionDetails.php');
-require_once('Braintree/WebhookNotification.php');
-require_once('Braintree/WebhookTesting.php');
-require_once('Braintree/Xml/Generator.php');
-require_once('Braintree/Xml/Parser.php');
-require_once('Braintree/CreditCardVerification.php');
-require_once('Braintree/CreditCardVerificationSearch.php');
-require_once('Braintree/PartnerMerchant.php');
-
-if (version_compare(PHP_VERSION, '5.2.1', '<')) {
-    throw new Braintree_Exception('PHP version >= 5.2.1 required');
-}
-
-
-function requireDependencies() {
-    $requiredExtensions = array('xmlwriter', 'SimpleXML', 'openssl', 'dom', 'hash', 'curl');
-    foreach ($requiredExtensions AS $ext) {
-        if (!extension_loaded($ext)) {
-            throw new Braintree_Exception('The Braintree library requires the ' . $ext . ' extension.');
-        }
-    }
-}
-
-requireDependencies();

--- a/lib/SplClassLoader.php
+++ b/lib/SplClassLoader.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+ 
+/**
+ * SplClassLoader implementation that implements the technical interoperability
+ * standards for PHP 5.3 namespaces and class names.
+ *
+ * http://groups.google.com/group/php-standards/web/psr-0-final-proposal?pli=1
+ *
+ *     // Example which loads classes for the Doctrine Common package in the
+ *     // Doctrine\Common namespace.
+ *     $classLoader = new SplClassLoader('Doctrine\Common', '/path/to/doctrine');
+ *     $classLoader->register();
+ *
+ * @license http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @author Jonathan H. Wage <jonwage@gmail.com>
+ * @author Roman S. Borschel <roman@code-factory.org>
+ * @author Matthew Weier O'Phinney <matthew@zend.com>
+ * @author Kris Wallsmith <kris.wallsmith@gmail.com>
+ * @author Fabien Potencier <fabien.potencier@symfony-project.org>
+ */
+class SplClassLoader
+{
+    private $_fileExtension = '.php';
+    private $_namespace;
+    private $_includePath;
+    private $_namespaceSeparator = '\\';
+
+    /**
+     * Creates a new <tt>SplClassLoader</tt> that loads classes of the
+     * specified namespace.
+     * 
+     * @param string $ns The namespace to use.
+     */
+    public function __construct($ns = null, $includePath = null)
+    {
+        $this->_namespace = $ns;
+        $this->_includePath = $includePath;
+    }
+
+    /**
+     * Sets the namespace separator used by classes in the namespace of this class loader.
+     * 
+     * @param string $sep The separator to use.
+     */
+    public function setNamespaceSeparator($sep)
+    {
+        $this->_namespaceSeparator = $sep;
+    }
+
+    /**
+     * Gets the namespace seperator used by classes in the namespace of this class loader.
+     *
+     * @return void
+     */
+    public function getNamespaceSeparator()
+    {
+        return $this->_namespaceSeparator;
+    }
+
+    /**
+     * Sets the base include path for all class files in the namespace of this class loader.
+     * 
+     * @param string $includePath
+     */
+    public function setIncludePath($includePath)
+    {
+        $this->_includePath = $includePath;
+    }
+
+    /**
+     * Gets the base include path for all class files in the namespace of this class loader.
+     *
+     * @return string $includePath
+     */
+    public function getIncludePath()
+    {
+        return $this->_includePath;
+    }
+
+    /**
+     * Sets the file extension of class files in the namespace of this class loader.
+     * 
+     * @param string $fileExtension
+     */
+    public function setFileExtension($fileExtension)
+    {
+        $this->_fileExtension = $fileExtension;
+    }
+
+    /**
+     * Gets the file extension of class files in the namespace of this class loader.
+     *
+     * @return string $fileExtension
+     */
+    public function getFileExtension()
+    {
+        return $this->_fileExtension;
+    }
+
+    /**
+     * Installs this class loader on the SPL autoload stack.
+     */
+    public function register()
+    {
+        spl_autoload_register(array($this, 'loadClass'));
+    }
+
+    /**
+     * Uninstalls this class loader from the SPL autoloader stack.
+     */
+    public function unregister()
+    {
+        spl_autoload_unregister(array($this, 'loadClass'));
+    }
+
+    /**
+     * Loads the given class or interface.
+     *
+     * @param string $className The name of the class to load.
+     * @return void
+     */
+    public function loadClass($className)
+    {
+        if (null === $this->_namespace || $this->_namespace.$this->_namespaceSeparator === substr($className, 0, strlen($this->_namespace.$this->_namespaceSeparator))) {
+            $fileName = '';
+            $namespace = '';
+            if (false !== ($lastNsPos = strripos($className, $this->_namespaceSeparator))) {
+                $namespace = substr($className, 0, $lastNsPos);
+                $className = substr($className, $lastNsPos + 1);
+                $fileName = str_replace($this->_namespaceSeparator, DIRECTORY_SEPARATOR, $namespace) . DIRECTORY_SEPARATOR;
+            }
+            $fileName .= str_replace('_', DIRECTORY_SEPARATOR, $className) . $this->_fileExtension;
+
+            $filePath = $this->_includePath !== null ? $this->_includePath . DIRECTORY_SEPARATOR : '' . $fileName;
+
+            if (file_exists ($filePath)) {
+                require ($filePath);
+            }
+            // Otherwise we let other registered autoloaders handle this.
+        }
+    }
+}
+

--- a/lib/loader.php
+++ b/lib/loader.php
@@ -1,0 +1,25 @@
+<?php
+
+// A bit of shielding for users that don't use composer.
+if (version_compare(PHP_VERSION, '5.2.1', '<')) {
+    throw new Braintree_Exception('PHP version >= 5.2.1 required');
+}
+
+
+function requireDependencies() {
+    $requiredExtensions = array('xmlwriter', 'SimpleXML', 'openssl', 'dom', 'hash', 'curl');
+    foreach ($requiredExtensions AS $ext) {
+        if (!extension_loaded($ext)) {
+            throw new Braintree_Exception('The Braintree library requires the ' . $ext . ' extension.');
+        }
+    }
+}
+
+requireDependencies();
+
+// OK now let's start the autoloader.
+require_once('SplClassLoader.php');
+
+$braintreeLoader = new SplClassLoader();
+$braintreeLoader->register();
+

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -5,7 +5,7 @@ set_include_path(
   realpath(dirname(__FILE__)) . '/../lib'
 );
 
-require_once "loader.php";
+require_once "Braintree.php";
 require_once "Braintree/CreditCardNumbers/CardTypeIndicators.php";
 require_once "Braintree/CreditCardDefaults.php";
 

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -5,7 +5,7 @@ set_include_path(
   realpath(dirname(__FILE__)) . '/../lib'
 );
 
-require_once "Braintree.php";
+require_once "loader.php";
 require_once "Braintree/CreditCardNumbers/CardTypeIndicators.php";
 require_once "Braintree/CreditCardDefaults.php";
 


### PR DESCRIPTION
I added the reference PSR-0 autoloader and moved the default file to manually require to *loader.php*. Updated the Readme accordingly.

The *Braintree.php* file attempts to detect whether a suitable autoloader is operating (such as provided by composer). If not, it will load the *loader.php* file as an attempt to be backwards-compatible.

I ran unit tests and everything seems ok.