### PR TITLE
Fix notices caused by Braintree_Instance not having '_attributes' define...

### DIFF
--- a/lib/Braintree/DisbursementDetails.php
+++ b/lib/Braintree/DisbursementDetails.php
@@ -23,8 +23,6 @@
  */
 class Braintree_DisbursementDetails extends Braintree_Instance
 {
-    protected $_attributes = array();
-
     function isValid() {
         return !is_null($this->disbursementDate);
     }

--- a/lib/Braintree/Error/Validation.php
+++ b/lib/Braintree/Error/Validation.php
@@ -25,9 +25,9 @@
  */
 class Braintree_Error_Validation
 {
-   private $_attribute;
-   private $_code;
-   private $_message;
+    private $_attribute;
+    private $_code;
+    private $_message;
 
     /**
      * @ignore
@@ -60,5 +60,13 @@ class Braintree_Error_Validation
     {
         $varName = "_$name";
         return isset($this->$varName) ? $this->$varName : null;
+    }
+
+    /**
+     * Allow introspection of the existence of private 'read-only' properties.
+     */
+    public function  __isset($name)
+    {
+        return ($this->__get($name) !== null);
     }
 }

--- a/lib/Braintree/Instance.php
+++ b/lib/Braintree/Instance.php
@@ -17,6 +17,8 @@
  */
 abstract class Braintree_Instance
 {
+    protected $_attributes = array();
+
     /**
      *
      * @param array $aAttribs

--- a/tests/unit/WebhookNotificationTest.php
+++ b/tests/unit/WebhookNotificationTest.php
@@ -3,7 +3,7 @@ require_once realpath(dirname(__FILE__)) . '/../TestHelper.php';
 
 class Braintree_WebhookNotificationTest extends PHPUnit_Framework_TestCase
 {
-    function teardown()
+    function setUp()
     {
         // Fix overwritten configuration in wrong key check:
         integrationMerchantConfig();


### PR DESCRIPTION
...d (moved from class Braintree_DisbursementDetails #random). Defined Braintree_Error_Validation.__isset() so isset/empty can deal with the private properties. Fixed test Braintree_WebhookNotificationTest::testVerify() that was failing due to poisoned static state.

# Addition of Braintree_Error_Validation.__isset() Behavior Change
## 5.3.10
```
** Old and busted
string(5) "isset"
bool(false)
string(7) "empty()"
bool(true)

** New hotness
string(5) "isset"
bool(true)
string(7) "empty()"
bool(false)
```

## 5.5.9
```
** Old and busted
string(5) "isset"
bool(false)
string(7) "empty()"
bool(true)

** New hotness
string(5) "isset"
bool(true)
string(7) "empty()"
bool(false)
```

# Unit Tests (5.3.10)
## Before
```
PHPUnit 3.7.37 by Sebastian Bergmann.

...............................................................  63 / 155 ( 40%)
..................................................F............ 126 / 155 ( 81%)
.............................

Time: 413 ms, Memory: 12.00Mb

There was 1 failure:

1) Braintree_WebhookNotificationTest::testVerify
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'integration_public_key|c9f15b74b0d98635cd182c51e2703cffa83388c3'
+'integration_public_key|1b0bcd1e59d260f28be85a6239c0dd01120ededc'

/Users/benlake/code/tabletop-initiative/braintree_php/tests/unit/WebhookNotificationTest.php:15

FAILURES!
Tests: 155, Assertions: 343, Failures: 1.
```

## After
```
PHPUnit 3.7.37 by Sebastian Bergmann.

...............................................................  63 / 155 ( 40%)
............................................................... 126 / 155 ( 81%)
.............................

Time: 318 ms, Memory: 12.00Mb
OK (155 tests, 343 assertions)
```
