### PR TITLE
PHPDoc fixes

### DIFF
--- a/lib/Braintree/Transaction.php
+++ b/lib/Braintree/Transaction.php
@@ -352,7 +352,7 @@ final class Braintree_Transaction extends Braintree
      * @access public
      * @param array $attribs
      * @return object
-     * @throws Braintree_Exception_ValidationError
+     * @throws Braintree_Exception_ValidationsFailed
      */
     public static function creditNoValidate($attribs)
     {
@@ -364,6 +364,9 @@ final class Braintree_Transaction extends Braintree
     /**
      * @access public
      *
+     * @param string $id
+     * @return Braintree_Transaction
+     * @throws Braintree_Exception_NotFound
      */
     public static function find($id)
     {
@@ -381,7 +384,7 @@ final class Braintree_Transaction extends Braintree
     /**
      * new sale
      * @param array $attribs
-     * @return array
+     * @return Braintree_Transaction
      */
     public static function sale($attribs)
     {
@@ -693,7 +696,7 @@ final class Braintree_Transaction extends Braintree
      * sends the create request to the gateway
      *
      * @ignore
-     * @param var $url
+     * @param string $url
      * @param array $params
      * @return mixed
      */


### PR DESCRIPTION
Many methods lack proper PHPDoc documentation, or are documented with mistakes.

This PR fixes a few of the most annoying PHPDoc bugs in `Braintree_Transaction`.