### PR TITLE
Remove possible whitespace from configuration

### DIFF
--- a/lib/Braintree/Configuration.php
+++ b/lib/Braintree/Configuration.php
@@ -140,22 +140,22 @@ class Braintree_Configuration extends Braintree
      */
     public static function environment($value = null)
     {
-        return self::setOrGet(__FUNCTION__, $value);
+        return self::setOrGet(__FUNCTION__, trim($value));
     }
 
     public static function merchantId($value = null)
     {
-        return self::setOrGet(__FUNCTION__, $value);
+        return self::setOrGet(__FUNCTION__, trim($value));
     }
 
     public static function publicKey($value = null)
     {
-        return self::setOrGet(__FUNCTION__, $value);
+        return self::setOrGet(__FUNCTION__, trim($value));
     }
 
     public static function privateKey($value = null)
     {
-        return self::setOrGet(__FUNCTION__, $value);
+        return self::setOrGet(__FUNCTION__, trim($value));
     }
     /**#@-*/
 


### PR DESCRIPTION
Simple code to clean up configuration values to prevent issues such as a 404 error on transaction submission caused by trailing whitespace on the merchantId.