### PR TITLE
Update WebhookTesting.php

### DIFF
--- a/lib/Braintree/WebhookTesting.php
+++ b/lib/Braintree/WebhookTesting.php
@@ -7,8 +7,8 @@ class Braintree_WebhookTesting
         $signature = Braintree_Configuration::publicKey() . "|" . Braintree_Digest::hexDigestSha1(Braintree_Configuration::privateKey(), $payload);
 
         return array(
-            'signature' => $signature,
-            'payload' => $payload
+            'bt_signature' => $signature,
+            'bt_payload' => $payload
         );
     }
 


### PR DESCRIPTION
bt_ prefix missing 
Sandbox and Productión environments send bt_payload and bt_signature as params when a webhook is fired.
To process the webhook call is needed to call Braintree_WebhookNotification::parse ( $parse, $payload )

In order to generate the same data as real enviroments expetcs, I suggets to add this bt_ prefix in at sampleNotification()
