### PR TITLE
Map to all paymentMethods for consistency of access.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you offer multiple payment types. E.G. CreditCards, PayPal, and Apple Pay. Yo
 <?php
 
 // Load up a customer with multiple saved paymentMethods.
-$customer = Braintree_Customer::find('85011179');
+$customer = Braintree_Customer::find('a_customer_id');
 
 // Loop throgh all of the payment methods of different types stored for user
 foreach ($customer->paymentMethods() as $paymentMethod) {
@@ -93,12 +93,12 @@ foreach ($customer->paymentMethods() as $paymentMethod) {
     print_r("isDefault: " . $paymentMethod->isDefault() . "\n ");
     print_r("image: <img src=\"" . $paymentMethod->imageUrl . "\"/>\n ");
     
-    // A little bit of custom logic however is needed to find a label to present to the customer.
+    // Some simple logic can be used to find a label to put beside the image.
     print_r("accountIdentifier: " . getAccountIdentifier ($paymentMethod). "\n ");
 
 }
 
-//A simple function helps us get a label across different object types.
+// This function helps us get a label across different object types.
 function getAccountIdentifier ($paymentMethod){
 
   // We can use the class to determine the type of paymentObject.
@@ -112,6 +112,7 @@ function getAccountIdentifier ($paymentMethod){
     case "Braintree_EuropeBankAccount":
         return $paymentMethod->maskedIban;
   }
+
 }
 
 ?>

--- a/README.md
+++ b/README.md
@@ -49,6 +49,49 @@ if ($result->success) {
 ?>
 ```
 
+## Looping Through Collections of Objects
+Iterating through the results of a transaction or customer search will fetch the individual object details.
+
+```php
+<?php
+
+
+$now = new Datetime();
+$past = clone $now;
+$past = $past->modify("-2 days");
+
+//Lets get all the sales in the past 2 days.
+$collection = Braintree_Transaction::search(array(
+  Braintree_TransactionSearch::createdAt()->between($past, $now),
+  Braintree_TransactionSearch::type()->is(Braintree_Transaction::SALE)
+));
+
+//loop throgh the collection to get access to individual transation objects.
+foreach ($collection as $transaction) {
+    print_r("transactionId ". $transaction->id . "\n");
+    print_r("firstName: " . $transaction->customerDetails->firstName . "\n");
+    print_r("amount: $" . $transaction->amount . "\n");
+    print_r("paymentInstrument: " . $transaction->paymentInstrumentType . "\n ");
+}
+
+?>
+```
+## Finding Customer Payment Methods
+If you offer multiple payment types. E.G. CreditCards, PayPal, and Apple Pay. You can use the paymentMethods() lookup to find all options easily. 
+
+```php
+<?php
+
+//lookup a customer with multiple saved paymentMethods
+$customer = Braintree_Customer::find('a_customer_id');
+
+//loop throgh all of the payment methods.
+foreach ($custtomer->paymentMethods() as $paymentMethod) {
+    print_r($paymentMethod);
+}
+
+?>
+```
 ## Documentation
 
  * [Official documentation](https://developers.braintreepayments.com/php/sdk/server/overview)

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ Iterating through the results of a transaction or customer search will fetch the
 ```php
 <?php
 
-
+//Lets get some details for all of the sales that took place in the past 2 days.
 $now = new Datetime();
 $past = clone $now;
 $past = $past->modify("-2 days");
 
-//Lets get all the sales in the past 2 days.
+//lookup up a collection of sale transactions.
 $collection = Braintree_Transaction::search(array(
   Braintree_TransactionSearch::createdAt()->between($past, $now),
   Braintree_TransactionSearch::type()->is(Braintree_Transaction::SALE)
@@ -82,12 +82,36 @@ If you offer multiple payment types. E.G. CreditCards, PayPal, and Apple Pay. Yo
 ```php
 <?php
 
-//lookup a customer with multiple saved paymentMethods
-$customer = Braintree_Customer::find('a_customer_id');
+// Load up a customer with multiple saved paymentMethods.
+$customer = Braintree_Customer::find('85011179');
 
-//loop throgh all of the payment methods.
-foreach ($custtomer->paymentMethods() as $paymentMethod) {
-    print_r($paymentMethod);
+// Loop throgh all of the payment methods of different types stored for user
+foreach ($customer->paymentMethods() as $paymentMethod) {
+
+    // All paymentMethod types can return basic fields consistently
+    print_r("token: ". $paymentMethod->token . "\n");
+    print_r("isDefault: " . $paymentMethod->isDefault() . "\n ");
+    print_r("image: <img src=\"" . $paymentMethod->imageUrl . "\"/>\n ");
+    
+    // A little bit of custom logic however is needed to find a label to present to the customer.
+    print_r("accountIdentifier: " . getAccountIdentifier ($paymentMethod). "\n ");
+
+}
+
+//A simple function helps us get a label across different object types.
+function getAccountIdentifier ($paymentMethod){
+
+  // We can use the class to determine the type of paymentObject.
+  switch (get_class($paymentMethod)) { 
+    case "Braintree_CreditCard":
+        return $paymentMethod->maskedNumber;
+    case "Braintree_PayPalAccount":
+        return $paymentMethod->email;
+    case "Braintree_ApplePayCard":
+        return $paymentMethod->paymentInstrumentName;
+    case "Braintree_EuropeBankAccount":
+        return $paymentMethod->maskedIban;
+  }
 }
 
 ?>

--- a/lib/Braintree/Customer.php
+++ b/lib/Braintree/Customer.php
@@ -175,6 +175,10 @@ class Braintree_Customer extends Braintree
             }
         }
         $this->_set('applePayCards', $applePayCardArray);
+
+        // Also provide a map to all payment methods for consistency of accesss.
+        $this->_set('paymentMethods', array_merge($creditCardArray, $paypalAccountArray, $applePayCardArray, $coinbaseAccountArray));
+
     }
 
     /**


### PR DESCRIPTION
Updating the ability to call $customer->paymentMethods without referencing to the function.

This way it is consistent with other payment method lookups and the documentation online:
https://developers.braintreepayments.com/javascript+php/reference/response/payment-method