### PR TITLE
fromNonce function for PayPalAccountGateway and PaymentMethodGateway

### DIFF
--- a/lib/Braintree/PayPalAccountGateway.php
+++ b/lib/Braintree/PayPalAccountGateway.php
@@ -56,6 +56,29 @@ class Braintree_PayPalAccountGateway
     }
 
     /**
+     * Convert a payment method nonce to a paypal account
+     *
+     * @access public
+     * @param string $nonce payment method nonce
+     * @return object Braintree_PayPalAccount
+     * @throws Braintree_Exception_NotFound
+     */
+    public function fromNonce($nonce)
+    {
+        $this->_validateId($nonce, "nonce");
+        try {
+            $path = $this->_config->merchantPath() . '/payment_methods/from_nonce/' . $nonce;
+            $response = $this->_http->get($path);
+            return Braintree_PayPalAccount::factory($response['payPalAccount']);
+        } catch (Braintree_Exception_NotFound $e) {
+            throw new Braintree_Exception_NotFound(
+                'paypal account with nonce ' . $nonce . ' locked, consumed or not found'
+            );
+        }
+
+    }
+
+    /**
      * updates the paypalAccount record
      *
      * if calling this method in context, $token

--- a/lib/Braintree/PaymentMethodGateway.php
+++ b/lib/Braintree/PaymentMethodGateway.php
@@ -72,6 +72,36 @@ class Braintree_PaymentMethodGateway
 
     }
 
+    /**
+     * Convert a payment method nonce to a payment method
+     *
+     * @access public
+     * @param string $nonce payment method nonce
+     * @return object Braintree_CreditCard|Braintree_PayPalAccount
+     * @throws Braintree_Exception_NotFound
+     */
+    public function fromNonce($nonce)
+    {
+        $this->_validateId($nonce, "nonce");
+        try {
+            $path = $this->_config->merchantPath() . '/payment_methods/from_nonce/' . $nonce;
+            $response = $this->_http->get($path);
+            if (isset($response['creditCard']))
+                return Braintree_CreditCard::factory($response['creditCard']);
+            elseif (isset($response['payPalAccount']))
+                return Braintree_PayPalAccount::factory($response['payPalAccount']);
+            else
+                throw new Braintree_Exception_NotFound(
+                    'no payment method with nonce ' . $nonce . ' found'
+                );
+        } catch (Braintree_Exception_NotFound $e) {
+            throw new Braintree_Exception_NotFound(
+                'payment method with nonce ' . $nonce . ' locked, consumed or not found'
+            );
+        }
+
+    }
+
     public function update($token, $attribs)
     {
         Braintree_Util::verifyKeys(self::updateSignature(), $attribs);


### PR DESCRIPTION
The `fromNonce()` function from `CreditCardGateway` is very useful, but only if also available in `PayPalAccountGateway` and a generic version in `PaymentMethodGateway`. This pull requests brings the function to the two other gateways.

See: http://stackoverflow.com/q/30274732/1544337