### PR TITLE
Test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 composer.lock
 composer.phar
 *.tgz
+/build
+phpunit.xml

--- a/phpunit-coverage.xml.dist
+++ b/phpunit-coverage.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false">
+
+    <php>
+      <ini name="error_reporting" value="32767"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="unit">
+          <directory>./tests/unit</directory>
+        </testsuite>
+    </testsuites>
+    <logging>
+        <log type="coverage-html" target="build/coverage" />
+        <log type="coverage-clover" target="build/logs/clover.xml" />
+        <log type="junit" target="build/logs/junit.xml" />
+    </logging>
+    <filter>
+        <blacklist>
+              <directory suffix=".php">vendor</directory>
+              <directory suffix=".php">tests</directory>
+        </blacklist>
+    </filter>
+</phpunit>

--- a/tests/unit/SettlementBatchSummaryTest.php
+++ b/tests/unit/SettlementBatchSummaryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+require_once realpath(dirname(__FILE__)) . '/../TestHelper.php';
+
+class Braintree_SettlementBatchSummaryTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * 
+     * @var \Braintree_SettlementBatchSummary
+     */
+    private $summary;
+    
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->summary = \Braintree_SettlementBatchSummary::factory(array());
+    }
+
+    public function testFactory()
+    {
+        $this->assertInstanceOf('Braintree_SettlementBatchSummary', $this->summary);
+    }
+
+}


### PR DESCRIPTION
This adds a unit test to get the feel for how the existing tests are being done, and also adds a phpunit config for running coverage reports with only the unit test folder.

I thought that distributing that config might be helpful since non-Braintree folks are unable to run the integration tests, and adding tests before suggesting any cleanups makes them much more useful.

This also adds phpunit.xml to the .gitignore file.