### PR TITLE
Update Braintree.php

### DIFF
--- a/lib/Braintree.php
+++ b/lib/Braintree.php
@@ -138,6 +138,7 @@ require_once('Braintree/PaymentInstrumentType.php');
 require_once('Braintree/UnknownPaymentMethod.php');
 require_once('Braintree/Exception/TestOperationPerformedInProduction.php');
 require_once('Braintree/Test/Transaction.php');
+require_once('Braintree/TestingGateway.php');
 
 if (version_compare(PHP_VERSION, '5.4.0', '<')) {
     throw new Braintree_Exception('PHP version >= 5.4.0 required');


### PR DESCRIPTION
bugfix for "PHP Fatal error:  Class 'Braintree_TestingGateway' not found in " when use Braintree_Test_Transaction::settle or similar