### PR TITLE
Fix property type hint with proper class

### DIFF
--- a/lib/Braintree/Transaction.php
+++ b/lib/Braintree/Transaction.php
@@ -156,7 +156,7 @@ namespace Braintree;
  * @property-read Braintree\CreditCardDetails $creditCardDetails transaction credit card info
  * @property-read Braintree\CoinbaseAccountDetails $coinbaseDetails transaction Coinbase account info
  * @property-read Braintree\PayPalAccountDetails $paypalDetails transaction paypal account info
- * @property-read Braintree\Customer $customerDetails transaction customer info
+ * @property-read Braintree\Transaction\CustomerDetails $customerDetails transaction customer info
  * @property-read Braintree\VenmoAccount $venmoAccountDetails transaction Venmo Account info
  * @property-read array  $customFields custom fields passed with the request
  * @property-read string $processorResponseCode gateway response code


### PR DESCRIPTION
According to the https://github.com/bocharsky-bw/braintree_php/blob/c8f01f0f4b1302a4f639d6b7b08bb68ccdcb8b2d/lib/Braintree/Transaction.php#L303-L305