### PR TITLE
Add leading slash to the namespace

### DIFF
--- a/lib/Braintree/Result/Error.php
+++ b/lib/Braintree/Result/Error.php
@@ -31,8 +31,8 @@ use Braintree\Error\ErrorCollection;
  * @copyright  2015 Braintree, a division of PayPal, Inc.
  *
  * @property-read array $params original passed params
- * @property-read Braintree\Error\ErrorCollection $errors
- * @property-read Braintree\Result\CreditCardVerification $creditCardVerification credit card verification data
+ * @property-read \Braintree\Error\ErrorCollection $errors
+ * @property-read \Braintree\Result\CreditCardVerification $creditCardVerification credit card verification data
  */
 class Error extends Base
 {


### PR DESCRIPTION
The IDEs (for example, PhpStorm) incorrectly resolve namespaces without leading slash.

Possible solution could be to use namespace first and then use only class name instead of FQCN:

```php
use Braintree\Error\ErrorCollection;

/**
 * ...
 * @property-read ErrorCollection $errors
 * ...
 */
class Error extends Base
```