### PR TITLE
Fix: Stop modifying DateTime  parameters during XML generation.

### DIFF
--- a/lib/Braintree/Xml/Generator.php
+++ b/lib/Braintree/Xml/Generator.php
@@ -130,8 +130,10 @@ class Generator
      */
     private static function _dateTimeToXmlTimestamp($dateTime)
     {
-        $dateTime->setTimeZone(new DateTimeZone('UTC'));
-        return ($dateTime->format('Y-m-d\TH:i:s') . 'Z');
+        $dateTimeForUTC = clone $dateTime;
+
+        $dateTimeForUTC->setTimeZone(new DateTimeZone('UTC'));
+        return ($dateTimeForUTC->format('Y-m-d\TH:i:s') . 'Z');
     }
 
     private static function _castDateTime($string)

--- a/tests/unit/Xml_GeneratorTest.php
+++ b/tests/unit/Xml_GeneratorTest.php
@@ -107,4 +107,28 @@ XML;
         ]);
         $this->assertEquals($expected, $xml);
     }
+
+    public function testDoesNotModifyDateTime()
+    {
+        $date = new \DateTime();
+        $date->setTimestamp(strtotime('2016-05-17T21:22:26Z'));
+        $date->setTimezone(new \DateTimeZone('Europe/Paris'));
+
+        $originalDate = clone $date;
+
+        $expected = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+ <stuff type="datetime">2016-05-17T21:22:26Z</stuff>
+</root>
+
+XML;
+
+        $xml = Braintree\Xml::buildXmlFromArray([
+            'root' => ['stuff' => $date]
+        ]);
+
+        $this->assertEquals($originalDate, $date);
+        $this->assertEquals($expected, $xml);
+    }
 }


### PR DESCRIPTION
Pull request for https://github.com/braintree/braintree_php/issues/135.