### PR TITLE
Travis: initial configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: php
+
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+
+install:
+  - composer install
+
+script:
+  - vendor/bin/phpunit tests/unit/
+


### PR DESCRIPTION
It would be nice to run unit tests under Travis with every PR/push.

You can see here https://github.com/petrkotek/braintree_php/pull/1, that the build succeeds.

Would it be possible to enable travis for `braintree/braintree_php` repo? It should be possible to flick the switch at https://travis-ci.org/profile/braintree or https://travis-ci.org/braintree/braintree_php.