### PR TITLE
Implemented JsonSerializable interface

### DIFF
--- a/lib/Braintree/Address.php
+++ b/lib/Braintree/Address.php
@@ -27,7 +27,7 @@ namespace Braintree;
  * @property-read string $streetAddress
  * @property-read string $updatedAt
  */
-class Address extends Base
+class Address extends Base implements \JsonSerializable
 {
     /**
      * returns false if comparing object is not a Address,
@@ -53,6 +53,18 @@ class Address extends Base
     {
         return __CLASS__ . '[' .
                 Util::attributesToString($this->_attributes) . ']';
+    }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
     }
 
     /**

--- a/lib/Braintree/AmexExpressCheckoutCard.php
+++ b/lib/Braintree/AmexExpressCheckoutCard.php
@@ -28,7 +28,7 @@ namespace Braintree;
  * @property-read string $expirationMonth
  * @property-read string $expirationYear
  */
-class AmexExpressCheckoutCard extends Base
+class AmexExpressCheckoutCard extends Base implements \JsonSerializable
 {
     /* instance methods */
     /**
@@ -77,5 +77,18 @@ class AmexExpressCheckoutCard extends Base
 
         $this->_set('subscriptions', $subscriptionArray);
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+
 }
 class_alias('Braintree\AmexExpressCheckoutCard', 'Braintree_AmexExpressCheckoutCard');

--- a/lib/Braintree/AndroidPayCard.php
+++ b/lib/Braintree/AndroidPayCard.php
@@ -31,7 +31,7 @@ namespace Braintree;
  * @property-read string $virtualCardLast4
  * @property-read string $virtualCardType
  */
-class AndroidPayCard extends Base
+class AndroidPayCard extends Base implements \JsonSerializable
 {
     /* instance methods */
     /**
@@ -86,5 +86,18 @@ class AndroidPayCard extends Base
 
         $this->_set('subscriptions', $subscriptionArray);
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+
 }
 class_alias('Braintree\AndroidPayCard', 'Braintree_AndroidPayCard');

--- a/lib/Braintree/ApplePayCard.php
+++ b/lib/Braintree/ApplePayCard.php
@@ -26,7 +26,7 @@ namespace Braintree;
  * @property-read string $sourceDescription
  * @property-read string $updatedAt
  */
-class ApplePayCard extends Base
+class ApplePayCard extends Base implements \JsonSerializable
 {
     // Card Type
     const AMEX = 'Apple Pay - American Express';
@@ -72,6 +72,18 @@ class ApplePayCard extends Base
         $instance = new self();
         $instance->_initialize(array_merge($defaultAttributes, $attributes));
         return $instance;
+    }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
     }
 
     /**

--- a/lib/Braintree/CoinbaseAccount.php
+++ b/lib/Braintree/CoinbaseAccount.php
@@ -25,7 +25,7 @@ namespace Braintree;
  * @property-read string $userName
  * @property-read string $userEmail
  */
-class CoinbaseAccount extends Base
+class CoinbaseAccount extends Base implements \JsonSerializable
 {
     /**
      *  factory method: returns an instance of CoinbaseAccount
@@ -84,6 +84,18 @@ class CoinbaseAccount extends Base
     {
         return __CLASS__ . '[' .
                 Util::attributesToString($this->_attributes) .']';
+    }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
     }
 
 

--- a/lib/Braintree/CreditCard.php
+++ b/lib/Braintree/CreditCard.php
@@ -29,7 +29,7 @@ namespace Braintree;
  * @property-read string $token
  * @property-read string $updatedAt
  */
-class CreditCard extends Base
+class CreditCard extends Base implements \JsonSerializable
 {
     // Card Type
     const AMEX = 'American Express';
@@ -144,6 +144,18 @@ class CreditCard extends Base
 
             $this->_set('verification', CreditCardVerification::factory($verifications[0]));
         }
+    }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
     }
 
     private function _compareCreatedAtOnVerifications($verificationAttrib1, $verificationAttrib2)

--- a/lib/Braintree/Customer.php
+++ b/lib/Braintree/Customer.php
@@ -34,7 +34,7 @@ namespace Braintree;
  * @property-read string $updatedAt
  * @property-read string $website
  */
-class Customer extends Base
+class Customer extends Base implements \JsonSerializable
 {
     /**
      *
@@ -324,6 +324,18 @@ class Customer extends Base
     {
         return __CLASS__ . '[' .
                 Util::attributesToString($this->_attributes) .']';
+    }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
     }
 
     /**

--- a/lib/Braintree/DisbursementDetails.php
+++ b/lib/Braintree/DisbursementDetails.php
@@ -16,10 +16,22 @@ namespace Braintree;
  * @property-read string $success
  * @property-read string $disbursementDate
  */
-class DisbursementDetails extends Instance
+class DisbursementDetails extends Instance implements \JsonSerializable
 {
     public function isValid() {
         return !is_null($this->disbursementDate);
+    }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
     }
 }
 class_alias('Braintree\DisbursementDetails', 'Braintree_DisbursementDetails');

--- a/lib/Braintree/Dispute.php
+++ b/lib/Braintree/Dispute.php
@@ -16,7 +16,7 @@ namespace Braintree;
  * @property-read string $disbursementDate
  * @property-read object $transactionDetails
  */
-class Dispute extends Base
+class Dispute extends Base implements \JsonSerializable
 {
     protected $_attributes = [];
 
@@ -77,6 +77,18 @@ class Dispute extends Base
         }
         return __CLASS__ . '[' .
                 Util::attributesToString($displayAttributes) .']';
+    }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
     }
 }
 class_alias('Braintree\Dispute', 'Braintree_Dispute');

--- a/lib/Braintree/Dispute/TransactionDetails.php
+++ b/lib/Braintree/Dispute/TransactionDetails.php
@@ -20,8 +20,19 @@ use Braintree\Instance;
  * @property-read string $amount
  * @property-read string $id
  */
-class TransactionDetails extends Instance
+class TransactionDetails extends Instance implements \JsonSerializable
 {
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
 }
 
 class_alias('Braintree\Dispute\TransactionDetails', 'Braintree_Dispute_TransactionDetails');

--- a/lib/Braintree/EuropeBankAccount.php
+++ b/lib/Braintree/EuropeBankAccount.php
@@ -22,7 +22,7 @@ namespace Braintree;
  * @property-read string $masked-iban
  * @property-read string $token
  */
-class EuropeBankAccount extends Base
+class EuropeBankAccount extends Base implements \JsonSerializable
 {
 
     /* instance methods */
@@ -63,6 +63,18 @@ class EuropeBankAccount extends Base
     protected function _initialize($europeBankAccountAttribs)
     {
         $this->_attributes = $europeBankAccountAttribs;
+    }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
     }
 }
 class_alias('Braintree\EuropeBankAccount', 'Braintree_EuropeBankAccount');

--- a/lib/Braintree/MerchantAccount/AddressDetails.php
+++ b/lib/Braintree/MerchantAccount/AddressDetails.php
@@ -3,8 +3,21 @@ namespace Braintree\MerchantAccount;
 
 use Braintree\Instance;
 
-class AddressDetails extends Instance
+class AddressDetails extends Instance implements \JsonSerializable
 {
     protected $_attributes = [];
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+    
 }
 class_alias('Braintree\MerchantAccount\AddressDetails', 'Braintree_MerchantAccount_AddressDetails');

--- a/lib/Braintree/MerchantAccount/BusinessDetails.php
+++ b/lib/Braintree/MerchantAccount/BusinessDetails.php
@@ -3,7 +3,7 @@ namespace Braintree\MerchantAccount;
 
 use Braintree\Base;
 
-class BusinessDetails extends Base
+class BusinessDetails extends Base implements \JsonSerializable
 {
     protected function _initialize($businessAttribs)
     {
@@ -19,5 +19,18 @@ class BusinessDetails extends Base
         $instance->_initialize($attributes);
         return $instance;
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+    
 }
 class_alias('Braintree\MerchantAccount\BusinessDetails', 'Braintree_MerchantAccount_BusinessDetails');

--- a/lib/Braintree/MerchantAccount/FundingDetails.php
+++ b/lib/Braintree/MerchantAccount/FundingDetails.php
@@ -3,8 +3,21 @@ namespace Braintree\MerchantAccount;
 
 use Braintree\Instance;
 
-class FundingDetails extends Instance
+class FundingDetails extends Instance implements \JsonSerializable
 {
     protected $_attributes = [];
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+
 }
 class_alias('Braintree\MerchantAccount\FundingDetails', 'Braintree_MerchantAccount_FundingDetails');

--- a/lib/Braintree/MerchantAccount/IndividualDetails.php
+++ b/lib/Braintree/MerchantAccount/IndividualDetails.php
@@ -3,7 +3,7 @@ namespace Braintree\MerchantAccount;
 
 use Braintree\Base;
 
-class IndividualDetails extends Base
+class IndividualDetails extends Base implements \JsonSerializable
 {
     protected function _initialize($individualAttribs)
     {
@@ -19,5 +19,18 @@ class IndividualDetails extends Base
         $instance->_initialize($attributes);
         return $instance;
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+    
 }
 class_alias('Braintree\MerchantAccount\IndividualDetails', 'Braintree_MerchantAccount_IndividualDetails');

--- a/lib/Braintree/PartnerMerchant.php
+++ b/lib/Braintree/PartnerMerchant.php
@@ -16,7 +16,7 @@ namespace Braintree;
  * @property-read string $clientSideEncryptionKey
  * @property-read string $partnerMerchantId
  */
-class PartnerMerchant extends Base
+class PartnerMerchant extends Base implements \JsonSerializable
 {
     protected $_attributes = [];
 
@@ -38,5 +38,18 @@ class PartnerMerchant extends Base
     {
         $this->_attributes = $attributes;
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+    
 }
 class_alias('Braintree\PartnerMerchant', 'Braintree_PartnerMerchant');

--- a/lib/Braintree/PayPalAccount.php
+++ b/lib/Braintree/PayPalAccount.php
@@ -24,7 +24,7 @@ namespace Braintree;
  * @property-read string $token
  * @property-read string $imageUrl
  */
-class PayPalAccount extends Base
+class PayPalAccount extends Base implements \JsonSerializable
 {
     /**
      *  factory method: returns an instance of PayPalAccount
@@ -85,6 +85,17 @@ class PayPalAccount extends Base
                 Util::attributesToString($this->_attributes) . ']';
     }
 
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
 
     // static methods redirecting to gateway
 

--- a/lib/Braintree/Result/CreditCardVerification.php
+++ b/lib/Braintree/Result/CreditCardVerification.php
@@ -22,7 +22,7 @@ use Braintree\Util;
  * @property-read string $status
  *
  */
-class CreditCardVerification
+class CreditCardVerification implements \JsonSerializable
 {
     // Status
     const FAILED                   = 'failed';
@@ -84,6 +84,18 @@ class CreditCardVerification
     {
         return __CLASS__ . '[' .
                 Util::attributesToString($this->_attributes) . ']';
+    }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
     }
 
     public static function allStatuses()

--- a/lib/Braintree/Result/Error.php
+++ b/lib/Braintree/Result/Error.php
@@ -34,7 +34,7 @@ use Braintree\Error\ErrorCollection;
  * @property-read \Braintree\Error\ErrorCollection $errors
  * @property-read \Braintree\Result\CreditCardVerification $creditCardVerification credit card verification data
  */
-class Error extends Base
+class Error extends Base implements \JsonSerializable
 {
     /**
     * @var bool always false
@@ -120,5 +120,18 @@ class Error extends Base
         }
         return __CLASS__ .'[' . $output . ']';
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+    
 }
 class_alias('Braintree\Result\Error', 'Braintree_Result_Error');

--- a/lib/Braintree/Result/Successful.php
+++ b/lib/Braintree/Result/Successful.php
@@ -28,7 +28,7 @@ use Braintree\Util;
  * @subpackage Result
  * @copyright  2015 Braintree, a division of PayPal, Inc.
  */
-class Successful extends Instance
+class Successful extends Instance implements \JsonSerializable
 {
     /**
      *
@@ -78,6 +78,18 @@ class Successful extends Instance
            array_push($objects, $this->$returnObjectName);
        }
        return __CLASS__ . '[' . implode(', ', $objects) . ']';
+   }
+
+   /**
+    * create a json serializable representation of the object
+    * to be passed into json_encode().
+    * @ignore
+    * @return array
+    */
+   public function jsonSerialize()
+   {
+       $vars = get_object_vars($this);
+       return $vars;
    }
 
    private function _mapPropertyNamesToObjsToReturn($propertyNames, $objsToReturn) {

--- a/lib/Braintree/Subscription/StatusDetails.php
+++ b/lib/Braintree/Subscription/StatusDetails.php
@@ -19,7 +19,20 @@ use Braintree\Instance;
  * @property-read string $subscriptionSource
  * @property-read string $user
  */
-class StatusDetails extends Instance
+class StatusDetails extends Instance implements \JsonSerializable
 {
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+
 }
 class_alias('Braintree\Subscription\StatusDetails', 'Braintree_Subscription_StatusDetails');

--- a/lib/Braintree/Transaction.php
+++ b/lib/Braintree/Transaction.php
@@ -171,7 +171,7 @@ namespace Braintree;
  *
  */
 
-class Transaction extends Base
+class Transaction extends Base implements \JsonSerializable
 {
     // Transaction Status
     const AUTHORIZATION_EXPIRED    = 'authorization_expired';
@@ -415,6 +415,18 @@ class Transaction extends Base
         }
         return __CLASS__ . '[' .
                 Util::attributesToString($displayAttributes) .']';
+    }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
     }
 
     public function isEqual($otherTx)

--- a/lib/Braintree/Transaction/AddressDetails.php
+++ b/lib/Braintree/Transaction/AddressDetails.php
@@ -21,8 +21,21 @@ use Braintree\Instance;
  * @property-read string $postalCode
  * @property-read string $countryName
  */
-class AddressDetails extends Instance
+class AddressDetails extends Instance implements \JsonSerializable
 {
     protected $_attributes = [];
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+
 }
 class_alias('Braintree\Transaction\AddressDetails', 'Braintree_Transaction_AddressDetails');

--- a/lib/Braintree/Transaction/AmexExpressCheckoutCardDetails.php
+++ b/lib/Braintree/Transaction/AmexExpressCheckoutCardDetails.php
@@ -30,7 +30,7 @@ use Braintree\Instance;
  * @property-read string $expirationYear
  * @uses Instance inherits methods
  */
-class AmexExpressCheckoutCardDetails extends Instance
+class AmexExpressCheckoutCardDetails extends Instance implements \JsonSerializable
 {
     protected $_attributes = [];
 
@@ -41,5 +41,18 @@ class AmexExpressCheckoutCardDetails extends Instance
     {
         parent::__construct($attributes);
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+
 }
 class_alias('Braintree\Transaction\AmexExpressCheckoutCardDetails', 'Braintree_Transaction_AmexExpressCheckoutCardDetails');

--- a/lib/Braintree/Transaction/AndroidPayCardDetails.php
+++ b/lib/Braintree/Transaction/AndroidPayCardDetails.php
@@ -32,7 +32,7 @@ use Braintree\Instance;
  * @property-read string $virtualCardLast4
  * @property-read string $virtualCardType
  */
-class AndroidPayCardDetails extends Instance
+class AndroidPayCardDetails extends Instance implements \JsonSerializable
 {
     protected $_attributes = [];
 
@@ -45,5 +45,18 @@ class AndroidPayCardDetails extends Instance
         $this->_attributes['cardType'] = $this->virtualCardType;
         $this->_attributes['last4'] = $this->virtualCardLast4;
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+    
 }
 class_alias('Braintree\Transaction\AndroidPayCardDetails', 'Braintree_Transaction_AndroidPayCardDetails');

--- a/lib/Braintree/Transaction/ApplePayCardDetails.php
+++ b/lib/Braintree/Transaction/ApplePayCardDetails.php
@@ -26,7 +26,7 @@ use Braintree\Instance;
  * @property-read string $cardholderName
  * @property-read string $sourceDescription
  */
-class ApplePayCardDetails extends Instance
+class ApplePayCardDetails extends Instance implements \JsonSerializable
 {
     protected $_attributes = [];
 
@@ -37,5 +37,18 @@ class ApplePayCardDetails extends Instance
     {
         parent::__construct($attributes);
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+    
 }
 class_alias('Braintree\Transaction\ApplePayCardDetails', 'Braintree_Transaction_ApplePayCardDetails');

--- a/lib/Braintree/Transaction/CoinbaseDetails.php
+++ b/lib/Braintree/Transaction/CoinbaseDetails.php
@@ -25,7 +25,7 @@ use Braintree\Instance;
  * @property-read string $userEmail
  * @property-read string $imageUrl
  */
-class CoinbaseDetails extends Instance
+class CoinbaseDetails extends Instance implements \JsonSerializable
 {
     protected $_attributes = [];
 
@@ -36,5 +36,18 @@ class CoinbaseDetails extends Instance
     {
         parent::__construct($attributes);
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+    
 }
 class_alias('Braintree\Transaction\CoinbaseDetails', 'Braintree_Transaction_CoinbaseDetails');

--- a/lib/Braintree/Transaction/CreditCardDetails.php
+++ b/lib/Braintree/Transaction/CreditCardDetails.php
@@ -21,7 +21,7 @@ use Braintree\Instance;
  * @property-read string $maskedNumber
  * @property-read string $token
  */
-class CreditCardDetails extends Instance
+class CreditCardDetails extends Instance implements \JsonSerializable
 {
     protected $_attributes = [];
 
@@ -33,7 +33,19 @@ class CreditCardDetails extends Instance
         parent::__construct($attributes);
         $this->_attributes['expirationDate'] = $this->expirationMonth . '/' . $this->expirationYear;
         $this->_attributes['maskedNumber'] = $this->bin . '******' . $this->last4;
-
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+
 }
 class_alias('Braintree\Transaction\CreditCardDetails', 'Braintree_Transaction_CreditCardDetails');

--- a/lib/Braintree/Transaction/CustomerDetails.php
+++ b/lib/Braintree/Transaction/CustomerDetails.php
@@ -20,7 +20,18 @@ use Braintree\Instance;
  * @property-read string $phone
  * @property-read string $website
  */
-class CustomerDetails extends Instance
+class CustomerDetails extends Instance implements \JsonSerializable
 {
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
 }
 class_alias('Braintree\Transaction\CustomerDetails', 'Braintree_Transaction_CustomerDetails');

--- a/lib/Braintree/Transaction/EuropeBankAccountDetails.php
+++ b/lib/Braintree/Transaction/EuropeBankAccountDetails.php
@@ -19,7 +19,18 @@ use Braintree\Instance;
  * @property-read string $maskedIban
  * @property-read string $token
  */
-class EuropeBankAccountDetails extends Instance
+class EuropeBankAccountDetails extends Instance implements \JsonSerializable
 {
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
 }
 class_alias('Braintree\Transaction\EuropeBankAccountDetails', 'Braintree_Transaction_EuropeBankAccountDetails');

--- a/lib/Braintree/Transaction/PayPalDetails.php
+++ b/lib/Braintree/Transaction/PayPalDetails.php
@@ -28,7 +28,7 @@ use Braintree\Instance;
  * @property-read string $transactionFeeCurrencyIsoCode
  * @property-read string $description
  */
-class PayPalDetails extends Instance
+class PayPalDetails extends Instance implements \JsonSerializable
 {
     protected $_attributes = [];
 
@@ -39,5 +39,18 @@ class PayPalDetails extends Instance
     {
         parent::__construct($attributes);
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+    
 }
 class_alias('Braintree\Transaction\PayPalDetails', 'Braintree_Transaction_PayPalDetails');

--- a/lib/Braintree/Transaction/StatusDetails.php
+++ b/lib/Braintree/Transaction/StatusDetails.php
@@ -16,7 +16,18 @@ use Braintree\Instance;
  * @property-read string $transactionSource
  * @property-read string $user
  */
-class StatusDetails extends Instance
+class StatusDetails extends Instance implements \JsonSerializable
 {
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
 }
 class_alias('Braintree\Transaction\StatusDetails', 'Braintree_Transaction_StatusDetails');

--- a/lib/Braintree/Transaction/SubscriptionDetails.php
+++ b/lib/Braintree/Transaction/SubscriptionDetails.php
@@ -14,7 +14,18 @@ use Braintree\Instance;
  * @property-read string $billing_period_start_date
  * @property-read string $billing_period_end_date
  */
-class SubscriptionDetails extends Instance
+class SubscriptionDetails extends Instance implements \JsonSerializable
 {
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
 }
 class_alias('Braintree\Transaction\SubscriptionDetails', 'Braintree_Transaction_SubscriptionDetails');

--- a/lib/Braintree/Transaction/UsBankAccountDetails.php
+++ b/lib/Braintree/Transaction/UsBankAccountDetails.php
@@ -20,7 +20,7 @@ use Braintree\Instance;
  * @property-read string $imageUrl
  * @property-read string $bankName
  */
-class UsBankAccountDetails extends Instance
+class UsBankAccountDetails extends Instance implements \JsonSerializable
 {
     protected $_attributes = [];
 
@@ -30,7 +30,19 @@ class UsBankAccountDetails extends Instance
     public function __construct($attributes)
     {
         parent::__construct($attributes);
-
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+
 }
 class_alias('Braintree\Transaction\UsBankAccountDetails', 'Braintree_Transaction_UsBankAccountDetails');

--- a/lib/Braintree/Transaction/VenmoAccountDetails.php
+++ b/lib/Braintree/Transaction/VenmoAccountDetails.php
@@ -25,7 +25,7 @@ use Braintree\Instance;
  * @property-read string $venmo_user_id
  * @uses Instance inherits methods
  */
-class VenmoAccountDetails extends Instance
+class VenmoAccountDetails extends Instance implements \JsonSerializable
 {
     protected $_attributes = array();
 
@@ -36,5 +36,18 @@ class VenmoAccountDetails extends Instance
     {
         parent::__construct($attributes);
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+    
 }
 class_alias('Braintree\Transaction\VenmoAccountDetails', 'Braintree_Transaction_VenmoAccountDetails');

--- a/lib/Braintree/UsBankAccount.php
+++ b/lib/Braintree/UsBankAccount.php
@@ -25,7 +25,7 @@ namespace Braintree;
  * @property-read string $imageUrl
  * @property-read string $bankName
  */
-class UsBankAccount extends Base
+class UsBankAccount extends Base implements \JsonSerializable
 {
     /**
      *  factory method: returns an instance of UsBankAccount
@@ -67,6 +67,17 @@ class UsBankAccount extends Base
                 Util::attributesToString($this->_attributes) . ']';
     }
 
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
 
     // static methods redirecting to gateway
 

--- a/lib/Braintree/VenmoAccount.php
+++ b/lib/Braintree/VenmoAccount.php
@@ -23,7 +23,7 @@ namespace Braintree;
  * @property-read string $username
  * @property-read string $venmoUserId
  */
-class VenmoAccount extends Base
+class VenmoAccount extends Base implements \JsonSerializable
 {
     /* instance methods */
     /**
@@ -71,5 +71,18 @@ class VenmoAccount extends Base
 
         $this->_set('subscriptions', $subscriptionArray);
     }
+
+    /**
+     * create a json serializable representation of the object
+     * to be passed into json_encode().
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $vars = get_object_vars($this);
+        return $vars;
+    }
+    
 }
 class_alias('Braintree\VenmoAccount', 'Braintree_VenmoAccount');


### PR DESCRIPTION
Implemented \JsonSerializable interface in what appear to be key classes. This allows the user to echo some results directly to the client for JavaScript processing simply by passing BrainTree responses through PHP's json_encode(). If this creates a security issue, please let me know.