### PR TITLE
Configurable, Explicit set of CURLOPT_SSLVERSION

### DIFF
--- a/lib/Braintree/Configuration.php
+++ b/lib/Braintree/Configuration.php
@@ -27,12 +27,14 @@ class Configuration
     private $_proxyUser = null;
     private $_proxyPassword = null;
     private $_timeout = 60;
+    private $_curlSslVersion = self::TLS_1_2;
 
     /**
      * Braintree API version to use
      * @access public
      */
      const API_VERSION =  4;
+     const TLS_1_2 = 6;
 
     public function __construct($attribs = [])
     {
@@ -111,6 +113,14 @@ class Configuration
             return self::$global->getPrivateKey();
         }
         self::$global->setPrivateKey($value);
+    }
+
+    public static function curlSslVersion($value=null)
+    {
+        if (empty($value)) {
+            return self::$global->getCurlSslVersion();
+        }
+        self::$global->setCurlSslVersion($value);
     }
 
     /**
@@ -376,6 +386,16 @@ class Configuration
     public function getAccessToken()
     {
         return $this->_accessToken;
+    }
+
+    public function getCurlSslVersion()
+    {
+        return $this->_curlSslVersion;
+    }
+
+    public function setCurlSslVersion($sslVersion)
+    {
+        $this->_curlSslVersion = $sslVersion;
     }
 
     public function isAccessToken()

--- a/lib/Braintree/Http.php
+++ b/lib/Braintree/Http.php
@@ -104,7 +104,7 @@ class Http
     public function _doUrlRequest($httpVerb, $url, $requestBody = null)
     {
         $curl = curl_init();
-        curl_setopt($curl, CURLOPT_SSLVERSION, 6);
+        curl_setopt($curl, CURLOPT_SSLVERSION, $this->_config->curlSslVersion());
         curl_setopt($curl, CURLOPT_TIMEOUT, $this->_config->timeout());
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $httpVerb);
         curl_setopt($curl, CURLOPT_URL, $url);

--- a/lib/Braintree/Http.php
+++ b/lib/Braintree/Http.php
@@ -104,6 +104,7 @@ class Http
     public function _doUrlRequest($httpVerb, $url, $requestBody = null)
     {
         $curl = curl_init();
+        curl_setopt($curl, CURLOPT_SSLVERSION, 6);
         curl_setopt($curl, CURLOPT_TIMEOUT, $this->_config->timeout());
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $httpVerb);
         curl_setopt($curl, CURLOPT_URL, $url);

--- a/tests/Helper.php
+++ b/tests/Helper.php
@@ -66,7 +66,7 @@ class Helper
     public static function submitTrRequest($url, $regularParams, $trData)
     {
         $curl = curl_init();
-        curl_setopt($curl, CURLOPT_SSLVERSION, 6);
+        curl_setopt($curl, CURLOPT_SSLVERSION, Braintree\Configuration::$global->curlSslVersion());
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, false);
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'POST');
@@ -151,7 +151,7 @@ class Helper
         $token = $client_token['braintree_api']['access_token'];
 
         $curl = curl_init();
-        curl_setopt($curl, CURLOPT_SSLVERSION, 6);
+        curl_setopt($curl, CURLOPT_SSLVERSION, Braintree\Configuration::$global->curlSslVersion());
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "POST");
         curl_setopt($curl, CURLOPT_URL, $url);
 

--- a/tests/Helper.php
+++ b/tests/Helper.php
@@ -66,6 +66,7 @@ class Helper
     public static function submitTrRequest($url, $regularParams, $trData)
     {
         $curl = curl_init();
+        curl_setopt($curl, CURLOPT_SSLVERSION, 6);
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, false);
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'POST');
@@ -150,6 +151,7 @@ class Helper
         $token = $client_token['braintree_api']['access_token'];
 
         $curl = curl_init();
+        curl_setopt($curl, CURLOPT_SSLVERSION, 6);
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "POST");
         curl_setopt($curl, CURLOPT_URL, $url);
 

--- a/tests/integration/HttpClientApi.php
+++ b/tests/integration/HttpClientApi.php
@@ -26,6 +26,7 @@ class HttpClientApi extends Braintree\Http
     public function _doUrlRequest($httpVerb, $url, $requestBody = null)
     {
         $curl = curl_init();
+        curl_setopt($curl, CURLOPT_SSLVERSION, 6);
         curl_setopt($curl, CURLOPT_TIMEOUT, 60);
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $httpVerb);
         curl_setopt($curl, CURLOPT_URL, $url);

--- a/tests/integration/HttpClientApi.php
+++ b/tests/integration/HttpClientApi.php
@@ -26,7 +26,7 @@ class HttpClientApi extends Braintree\Http
     public function _doUrlRequest($httpVerb, $url, $requestBody = null)
     {
         $curl = curl_init();
-        curl_setopt($curl, CURLOPT_SSLVERSION, 6);
+        curl_setopt($curl, CURLOPT_SSLVERSION, $this->_config->curlSslVersion());
         curl_setopt($curl, CURLOPT_TIMEOUT, 60);
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $httpVerb);
         curl_setopt($curl, CURLOPT_URL, $url);


### PR DESCRIPTION
This expands on the patch by [blasto333 ](https://github.com/blasto333) in #161  by making the Explicit set of the CURLOPT_SSLVERSION configurable. It defaults to tls 1.2 if no configuration is specified.