### PR TITLE
README.md: This is "Client" library not a "Server" library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Braintree PHP Server Library
+# Braintree PHP Client Library
 
 The Braintree PHP library provides integration access to the Braintree Gateway.
 


### PR DESCRIPTION
Quite recently, title of the readme has been changed from `Braintree API Client Library` to `Braintree API Server Library`, which I believe, is wrong: https://github.com/braintree/braintree_php/commit/30165da99f35f0cb2fa13ef0a4bfc8340f23cdeb#diff-04c6e90faac2675aa89e2176d2eec7d8.

I suggest changing this back to `Client Library`.

Let me know what you think,
Thanks!