### PR TITLE
Remove duplicate property in AmexExpressCheckoutCard

### DIFF
--- a/lib/Braintree/AmexExpressCheckoutCard.php
+++ b/lib/Braintree/AmexExpressCheckoutCard.php
@@ -21,7 +21,6 @@ namespace Braintree;
  * @property-read string $bin
  * @property-read string $cardMemberExpiryDate
  * @property-read string $cardMemberNumber
- * @property-read string $cardType
  * @property-read string $sourceDescription
  * @property-read string $token
  * @property-read string $imageUrl


### PR DESCRIPTION
Property `$cardType` is 'declared' twice in `AmexExpressCheckoutCard`. This PR removes one of the two. (I know, very minor thingy ;) )