### PR TITLE
added __set_state() to Base and Instance

### DIFF
--- a/lib/Braintree/Base.php
+++ b/lib/Braintree/Base.php
@@ -74,4 +74,24 @@ abstract class Base
     {
         $this->_attributes[$key] = $value;
     }
+
+	/**
+	 * This static method is called for classes exported by var_export() since PHP 5.1.0.
+	 *
+	 * @param $properties array containing exported properties in the form array('property' => value, ...)
+	 *
+	 * @return created class
+	 */
+	static public function __set_state( $properties )
+	{
+		$c = get_called_class();
+
+		$class = new $c();
+
+		while ( ( list( $k, $v ) = each( $properties ) ) != false ) {
+			$class->$k = $v;
+		}
+
+		return $class;
+	}
 }

--- a/lib/Braintree/Instance.php
+++ b/lib/Braintree/Instance.php
@@ -71,5 +71,18 @@ abstract class Instance
         $this->_attributes = $attributes;
     }
 
+	/**
+	 * This static method is called for classes exported by var_export() since PHP 5.1.0.
+	 *
+	 * @param $properties array containing exported properties in the form array('property' => value, ...)
+	 *
+	 * @return created class
+	 */
+	static public function __set_state( $properties )
+	{
+		$c = get_called_class();
+
+		return new $c( ( array_key_exists( '_attributes', $properties ) ? $properties['_attributes'] : array() ) );
+	}
 }
 class_alias('Braintree\Instance', 'Braintree_Instance');


### PR DESCRIPTION
There are scenarios where a Braintree object can be saved to be processed later. For ex., when a webhook URL is called, the server simply saves the passed object into the DB and processes it asynchronously. The best way to do this, is to use var_export() with the Braintree object and to "recreate" it with __set_state().