### PR TITLE
Improved error reporting for connection issues.

### DIFF
--- a/lib/Braintree/Exception/Connection.php
+++ b/lib/Braintree/Exception/Connection.php
@@ -1,0 +1,17 @@
+<?php
+namespace Braintree\Exception;
+
+use Braintree\Exception;
+
+/**
+ * Raised when the connection fails
+ *
+ * @package    Braintree
+ * @subpackage Exception
+ * @copyright  2015 Braintree, a division of PayPal, Inc.
+ */
+class Connection extends Exception
+{
+
+}
+class_alias('Braintree\Exception\Connection', 'Braintree_Exception_Connection');

--- a/lib/Braintree/Http.php
+++ b/lib/Braintree/Http.php
@@ -167,11 +167,7 @@ class Http
         curl_close($curl);
         if ($this->_config->sslOn()) {
             if ($httpStatus == 0) {
-                if ($error_code == 35) {
-                    throw new Exception\SSLCertificate($error, $error_code);
-                } else {
-                    throw new Exception\Connection($error, $error_code);
-                }
+                throw new Exception\SSLCertificate($error, $error_code);
             }
         } else if ($error_code) {
             throw new Exception\Connection($error, $error_code);

--- a/lib/Braintree/Http.php
+++ b/lib/Braintree/Http.php
@@ -20,7 +20,7 @@ class Http
     public function delete($path)
     {
         $response = $this->_doRequest('DELETE', $path);
-        if($response['status'] === 200) {
+        if ($response['status'] === 200) {
             return true;
         } else {
             Util::throwStatusCodeException($response['status']);
@@ -41,7 +41,7 @@ class Http
     {
         $response = $this->_doRequest('POST', $path, $this->_buildXml($params));
         $responseCode = $response['status'];
-        if($responseCode === 200 || $responseCode === 201 || $responseCode === 422 || $responseCode == 400) {
+        if ($responseCode === 200 || $responseCode === 201 || $responseCode === 422 || $responseCode == 400) {
             return Xml::buildArrayFromXml($response['body']);
         } else {
             Util::throwStatusCodeException($responseCode);
@@ -52,7 +52,7 @@ class Http
     {
         $response = $this->_doRequest('PUT', $path, $this->_buildXml($params));
         $responseCode = $response['status'];
-        if($responseCode === 200 || $responseCode === 201 || $responseCode === 422 || $responseCode == 400) {
+        if ($responseCode === 200 || $responseCode === 201 || $responseCode === 422 || $responseCode == 400) {
             return Xml::buildArrayFromXml($response['body']);
         } else {
             Util::throwStatusCodeException($responseCode);
@@ -135,21 +135,21 @@ class Http
             curl_setopt($curl, CURLOPT_CAINFO, $this->getCaFile());
         }
 
-        if(!empty($requestBody)) {
+        if (!empty($requestBody)) {
             curl_setopt($curl, CURLOPT_POSTFIELDS, $requestBody);
         }
 
-        if($this->_config->isUsingProxy()) {
+        if ($this->_config->isUsingProxy()) {
             $proxyHost = $this->_config->getProxyHost();
             $proxyPort = $this->_config->getProxyPort();
             $proxyType = $this->_config->getProxyType();
             $proxyUser = $this->_config->getProxyUser();
             $proxyPwd= $this->_config->getProxyPassword();
             curl_setopt($curl, CURLOPT_PROXY, $proxyHost . ':' . $proxyPort);
-            if(!empty($proxyType)) {
+            if (!empty($proxyType)) {
                 curl_setopt($curl, CURLOPT_PROXYTYPE, $proxyType);
             }
-            if($this->_config->isAuthenticatedProxy()) {
+            if ($this->_config->isAuthenticatedProxy()) {
                 curl_setopt($curl, CURLOPT_PROXYUSERPWD, $proxyUser . ':' . $proxyPwd);
             }
         }
@@ -167,13 +167,13 @@ class Http
         curl_close($curl);
         if ($this->_config->sslOn()) {
             if ($httpStatus == 0) {
-                if($error_code == 35) {
+                if ($error_code == 35) {
                     throw new Exception\SSLCertificate($error, $error_code);
                 } else {
                     throw new Exception\Connection($error, $error_code);
                 }
             }
-        } else if($error_code) {
+        } else if ($error_code) {
             throw new Exception\Connection($error, $error_code);
         }
 

--- a/tests/integration/HttpTest.php
+++ b/tests/integration/HttpTest.php
@@ -84,8 +84,6 @@ class HttpTest extends Setup
         Braintree\Configuration::environment('development');
     }
 
-
-
     public function testAcceptGzipEncodingSetFalse()
     {
         $originalGzipEncoding = Braintree\Configuration::acceptGzipEncoding();

--- a/tests/integration/HttpTest.php
+++ b/tests/integration/HttpTest.php
@@ -58,7 +58,7 @@ class HttpTest extends Setup
         try {
             Braintree\Configuration::environment('sandbox');
             Braintree\Configuration::sslVersion(3);
-            $this->setExpectedException('Braintree\Exception\SSLCertificate');
+            $this->setExpectedException('Braintree\Exception\SSLCertificate', null, 35);
             $http = new Braintree\Http(Braintree\Configuration::$global);
             $http->get('/');
         } catch (Braintree\Exception $e) {
@@ -74,7 +74,7 @@ class HttpTest extends Setup
     {
         try {
             Braintree\Configuration::environment('sandbox');
-            $this->setExpectedException('Braintree\Exception\SSLCertificate');
+            $this->setExpectedException('Braintree\Exception\Connection', null, 3);
             $http = new Braintree\Http(Braintree\Configuration::$global);
             $http->_doUrlRequest('get', '/malformed_url');
         } catch (Braintree\Exception $e) {
@@ -83,6 +83,8 @@ class HttpTest extends Setup
         }
         Braintree\Configuration::environment('development');
     }
+
+
 
     public function testAcceptGzipEncodingSetFalse()
     {

--- a/tests/integration/HttpTest.php
+++ b/tests/integration/HttpTest.php
@@ -74,7 +74,7 @@ class HttpTest extends Setup
     {
         try {
             Braintree\Configuration::environment('sandbox');
-            $this->setExpectedException('Braintree\Exception\Connection', null, 3);
+            $this->setExpectedException('Braintree\Exception\SSLCertificate', null, 3);
             $http = new Braintree\Http(Braintree\Configuration::$global);
             $http->_doUrlRequest('get', '/malformed_url');
         } catch (Braintree\Exception $e) {

--- a/tests/unit/HttpTest.php
+++ b/tests/unit/HttpTest.php
@@ -1,0 +1,67 @@
+<?php
+namespace Test\Unit;
+
+require_once dirname(__DIR__) . '/Setup.php';
+
+use Test\Setup;
+use Braintree;
+
+class HttpTest extends Setup
+{
+    /**TODO LIST OF THINGS TO DO STILL
+     * 1) Review changes, ensure we didn't break integration tests
+     * 2) See if we need to broaden our exception
+     * 3) See if we should check for other SSL related codes
+     * 4) See if we should change these tests a bit to be more unique and less a copy and paste job
+     */
+
+    public function testMalformedNoSsl()
+    {
+        try {
+            Braintree\Configuration::environment('development');
+            $this->setExpectedException('Braintree\Exception\Connection', null, 3);
+            $http = new Braintree\Http(Braintree\Configuration::$global);
+            $http->_doUrlRequest('get', '/a_malformed_url');
+        } catch (Braintree\Exception $e) {
+            throw $e;
+        }
+    }
+
+    public function testMalformedUrlUsingSsl()
+    {
+        try {
+            Braintree\Configuration::environment('sandbox');
+            $this->setExpectedException('Braintree\Exception\Connection', null, 3);
+            $http = new Braintree\Http(Braintree\Configuration::$global);
+            $http->_doUrlRequest('get', '/a_malformed_url_using_ssl');
+        } catch (Braintree\Exception $e) {
+            Braintree\Configuration::environment('development');
+            throw $e;
+        }
+        Braintree\Configuration::environment('development');
+    }
+
+    public function testSSLVersionError()
+    {
+        try {
+            Braintree\Configuration::environment('sandbox');
+            Braintree\Configuration::sslVersion(3);
+            $this->setExpectedException('Braintree\Exception\SSLCertificate', null, 35);
+            $http = new Braintree\Http(Braintree\Configuration::$global);
+            $http->get('/');
+        } catch (Braintree\Exception $e) {
+            Braintree\Configuration::environment('development');
+            Braintree\Configuration::sslVersion(null);
+            throw $e;
+        }
+        Braintree\Configuration::environment('development');
+        Braintree\Configuration::sslVersion(null);
+    }
+
+    public function testGoodRequest()
+    {
+        Braintree\Configuration::environment('development');
+        $http = new Braintree\Http(Braintree\Configuration::$global);
+        $http->_doUrlRequest('get', 'http://example.com');
+    }
+}

--- a/tests/unit/HttpTest.php
+++ b/tests/unit/HttpTest.php
@@ -8,13 +8,6 @@ use Braintree;
 
 class HttpTest extends Setup
 {
-    /**TODO LIST OF THINGS TO DO STILL
-     * 1) Review changes, ensure we didn't break integration tests
-     * 2) See if we need to broaden our exception
-     * 3) See if we should check for other SSL related codes
-     * 4) See if we should change these tests a bit to be more unique and less a copy and paste job
-     */
-
     public function testMalformedNoSsl()
     {
         try {

--- a/tests/unit/HttpTest.php
+++ b/tests/unit/HttpTest.php
@@ -31,7 +31,7 @@ class HttpTest extends Setup
     {
         try {
             Braintree\Configuration::environment('sandbox');
-            $this->setExpectedException('Braintree\Exception\Connection', null, 3);
+            $this->setExpectedException('Braintree\Exception\SSLCertificate', null, 3);
             $http = new Braintree\Http(Braintree\Configuration::$global);
             $http->_doUrlRequest('get', '/a_malformed_url_using_ssl');
         } catch (Braintree\Exception $e) {


### PR DESCRIPTION
This modifies the existing exception throwing in `Http.php` to add any error message and code available from curl for a given request. 

Additionally since not all errors are ssl related this adds a new `Connection` exception to more generally categorize issues that are not necessarily SSL related. This also checks for and throws exceptions if errors are present when SSL is off.

This is intended to assist in developers pinpointing issues. Such an example is #173 , where an error unrelated to the SDK was being reported as just an `SSLCertificate` exception with no details of the curl error code or message. In the current setup any connection error would be thrown as an `SSLCertificate` exception with no details, whether it is related to the sdk or not.

This adds a new unit test file for checking the behavior of this newly added code. The relevant integration tests have been updated as well.

I should note I have _not_ run the integration tests, as I did not see an obvious means of doing so. I did look through everything and found [fake_braintree](https://github.com/braintree/fake_braintree) that seems to be just for this purpose, but it hasn't been updated since 2012 and I'm unsure of it's state in relation to the actual live service. Other than that I'll wait to see what anyone at braintree has to say regarding an appropriate means of running integration tests.

Also if there's any thoughts about the new `Connection` exception to the SDK, let me know. It may be something braintree is ok with, but if not I can make the changes to utilize the existing `SSLCertificate` exception in place of the `Connection` exception, but with the curl message & code set of course.