### PR TITLE
update return type for client token

### DIFF
--- a/lib/Braintree/ClientToken.php
+++ b/lib/Braintree/ClientToken.php
@@ -11,7 +11,7 @@ class ClientToken
     /**
      *
      * @param array $params
-     * @return array
+     * @return string
      */
     public static function generate($params=[])
     {


### PR DESCRIPTION
[d9a26cb](https://github.com/braintree/braintree_php/commit/d9a26cbe789d852c9657a8c6f7803708da16982e) updated the docblock in the ClientTokenGateway, but that doesn't seem to have bubbled up to here.