### PR TITLE
fix curl "Peer reports incompatible or unsupported protocol version"

### DIFF
--- a/lib/Braintree/Http.php
+++ b/lib/Braintree/Http.php
@@ -152,6 +152,9 @@ class Http
             }
         }
 
+        //in case of Peer reports incompatible or unsupported protocol version
+        curl_setopt($curl, CURLOPT_SSLVERSION, 6);
+
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         $response = curl_exec($curl);
         $httpStatus = curl_getinfo($curl, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
since the  ssl version of "https://api.sandbox.braintreegateway.com"
needs TLSv12,
your should set sslversion,otherwise,you will encounter with problem
"Peer reports incompatible or unsupported protocol version"

-- my php version is 5.5.36 and my openssl version =OpenSSL 1.0.1e-fips