### PR TITLE
create_function is deprecated in PHP 7.2

### DIFF
--- a/lib/Braintree/Util.php
+++ b/lib/Braintree/Util.php
@@ -203,8 +203,8 @@ class Util
         static $callback = null;
         if ($callback === null) {
             $callback = function ($matches) {
-				return strtoupper($matches[1]);
-			};
+                return strtoupper($matches[1]);
+            };
         }
 
         return preg_replace_callback('/' . $delimiter . '(\w)/', $callback, $string);

--- a/lib/Braintree/Util.php
+++ b/lib/Braintree/Util.php
@@ -200,12 +200,11 @@ class Util
      */
     public static function delimiterToCamelCase($string, $delimiter = '[\-\_]')
     {
-        // php doesn't garbage collect functions created by create_function()
-        // so use a static variable to avoid adding a new function to memory
-        // every time this function is called.
         static $callback = null;
         if ($callback === null) {
-            $callback = create_function('$matches', 'return strtoupper($matches[1]);');
+            $callback = function ($matches) {
+				return strtoupper($matches[1]);
+			};
         }
 
         return preg_replace_callback('/' . $delimiter . '(\w)/', $callback, $string);


### PR DESCRIPTION
Although the reasons for using `create_function()` in the first place were valid; it is unfortunately now deprecated in PHP 7.2.

I've updated it to use a closure instead, alternatively the callback definition could be conditional on PHP version if that is preferred.