### PR TITLE
Update Base.php to implement JsonSerializable

### DIFF
--- a/lib/Braintree/Base.php
+++ b/lib/Braintree/Base.php
@@ -83,8 +83,6 @@ abstract class Base implements JsonSerializable
      */
     public function jsonSerialize()
     {
-	    return $this->_attributes;
+	return $this->_attributes;
     }
-    
-    
 }

--- a/lib/Braintree/Base.php
+++ b/lib/Braintree/Base.php
@@ -76,11 +76,11 @@ abstract class Base implements JsonSerializable
     }
     
     /**
-	 * Implementation of JsonSerializable 
-	 * 
-	 * @ignore
-	 * @return array
-	 */
+     * Implementation of JsonSerializable 
+     * 
+     * @ignore
+     * @return array
+     */
     public function jsonSerialize()
     {
 	    return $this->_attributes;

--- a/lib/Braintree/Base.php
+++ b/lib/Braintree/Base.php
@@ -1,6 +1,8 @@
 <?php
 namespace Braintree;
 
+use JsonSerializable;
+
 /**
  * Braintree PHP Library.
  *
@@ -9,7 +11,7 @@ namespace Braintree;
  *
  *  PHP version 5
  */
-abstract class Base
+abstract class Base implements JsonSerializable
 {
     protected $_attributes = [];
 
@@ -72,4 +74,17 @@ abstract class Base
     {
         $this->_attributes[$key] = $value;
     }
+    
+    /**
+	 * Implementation of JsonSerializable 
+	 * 
+	 * @ignore
+	 * @return array
+	 */
+    public function jsonSerialize()
+    {
+	    return $this->_attributes;
+    }
+    
+    
 }


### PR DESCRIPTION
Currently logging complete responses from Braintree is cumbersome, requiring to either get() each item, or using Reflection to access the $_attributes array. This allows for an elegant solution for anyone wishing to retain the complete Braintree objects for transaction logs.

# Summary

Implement JsonSerializable on Braintree Objects extending Braintree\Base

# Checklist

- [ ] Added changelog entry
- [ ] Ran unit tests (Check the README for instructions)
