### PR TITLE
Fix 'Warning: Parameter 1 to end() expected to be a reference'

### DIFF
--- a/lib/Braintree/Http.php
+++ b/lib/Braintree/Http.php
@@ -211,7 +211,7 @@ class Http
         }
 
         // build file parameter
-        $filePath = call_user_func("end", explode(DIRECTORY_SEPARATOR, $filePath));
+        $filePath = end(explode(DIRECTORY_SEPARATOR, $filePath));
         $filePath = str_replace($disallow, "_", $filePath);
         $body[] = implode("\r\n", [
             "Content-Disposition: form-data; name=\"file\"; filename=\"{$filePath}\"",


### PR DESCRIPTION
When you try to upload file you get this warning 'Warning: Parameter 1 to end() expected to be a reference, value given.' and after that you get the error:

```
Fatal error: Uncaught Braintree\Exception\ServerError in /var/www/vendor/braintree/braintree_php/lib/Braintree/Util.php:71
Stack trace:
#0 /var/www/vendor/braintree/braintree_php/lib/Braintree/Http.php(61): Braintree\Util::throwStatusCodeException(500)
#1 /var/www/vendor/braintree/braintree_php/lib/Braintree/DocumentUploadGateway.php(62): Braintree\Http->postMultipart('/merchants/968p...', Array, Resource id #21)
#2 /var/www/vendor/braintree/braintree_php/lib/Braintree/DocumentUpload.php(35): Braintree\DocumentUploadGateway->create(Array)
#3 /var/www/test.php(14): Braintree\DocumentUpload::create(Array)
#4 {main}
  thrown in /var/www/vendor/braintree/braintree_php/lib/Braintree/Util.php on line 71
```

The parameters for call_user_func() are not passed by reference and the variable $filePath is NULL.

# Summary
Remove call_user_func() and directly call the function end().

# Checklist

- [ ] Added changelog entry
- [ ] Ran unit tests (Check the README for instructions)