### PR TITLE
Configuration fix

### DIFF
--- a/lib/Braintree/Configuration.php
+++ b/lib/Braintree/Configuration.php
@@ -71,6 +71,8 @@ class Configuration
             $this->_clientSecret = $parsedCredentials->getClientSecret();
             $this->_accessToken = $parsedCredentials->getAccessToken();
         }
+
+        self::$global = $this;
     }
 
     /**

--- a/lib/Braintree/WebhookTestingGateway.php
+++ b/lib/Braintree/WebhookTestingGateway.php
@@ -10,11 +10,11 @@ class WebhookTestingGateway
         $this->config->assertHasAccessTokenOrKeys();
     }
 
-    public static function sampleNotification($kind, $id, $sourceMerchantId = null)
+    public function sampleNotification($kind, $id, $sourceMerchantId = null)
     {
         $xml = self::_sampleXml($kind, $id, $sourceMerchantId);
         $payload = base64_encode($xml) . "\n";
-        $signature = Configuration::publicKey() . "|" . Digest::hexDigestSha1(Configuration::privateKey(), $payload);
+        $signature = $this->config->publicKey() . "|" . Digest::hexDigestSha1(Configuration::privateKey(), $payload);
 
         return [
             'bt_signature' => $signature,

--- a/tests/Setup.php
+++ b/tests/Setup.php
@@ -15,11 +15,6 @@ use PHPUnit_Framework_TestCase;
 
 class Setup extends PHPUnit_Framework_TestCase
 {
-    public function __construct()
-    {
-        self::integrationMerchantConfig();
-    }
-
     public static function integrationMerchantConfig()
     {
         Configuration::reset();
@@ -28,5 +23,10 @@ class Setup extends PHPUnit_Framework_TestCase
         Configuration::merchantId('integration_merchant_id');
         Configuration::publicKey('integration_public_key');
         Configuration::privateKey('integration_private_key');
+    }
+
+    protected function setUp()
+    {
+        $this->integrationMerchantConfig();
     }
 }


### PR DESCRIPTION
# Summary
This fixes #212.

Recap of the issue:
Using gateway instances the `Configuration::$global` never got set. Now the constructor for `Configuration` will set the static `$global` variable.

Once this was patched I noticed the tests were failing, this was being caused by poor isolation of the test cases. All test cases utilize the same static configuration object (you can't isolate static objects), but this object is set up when the test suite is started. Each time a mutation occurs during a test case that mutation would carry on to the next test case. To fix this, the `__construct` method that is called only when PHPUnit is started up was replaced with the `setUp` method that PHPUnit calls before each test case.

Finally, the `sampleNotification` method on the WebhookTestingGateway was marked as a `static` method, which causes issues with some IDEs autocomplete.

# Checklist

- [ ] Added changelog entry
- [ ] Ran unit tests (Check the README for instructions)
Unit tests were run on PHP 7.1.14