### PR TITLE
Ensure the sample webhook notification uses API credentials from the instantiated gateway.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Ensure the sample webhook notification generator uses API credentials from the instantiated gateway.
+
 ## 3.32.0
 * Add support for US Bank Account verifications API
 

--- a/lib/Braintree/WebhookTestingGateway.php
+++ b/lib/Braintree/WebhookTestingGateway.php
@@ -10,11 +10,11 @@ class WebhookTestingGateway
         $this->config->assertHasAccessTokenOrKeys();
     }
 
-    public static function sampleNotification($kind, $id, $sourceMerchantId = null)
+    public function sampleNotification($kind, $id, $sourceMerchantId = null)
     {
         $xml = self::_sampleXml($kind, $id, $sourceMerchantId);
         $payload = base64_encode($xml) . "\n";
-        $signature = Configuration::publicKey() . "|" . Digest::hexDigestSha1(Configuration::privateKey(), $payload);
+        $signature = $this->config->getPublicKey() . "|" . Digest::hexDigestSha1($this->config->getPrivateKey(), $payload);
 
         return [
             'bt_signature' => $signature,


### PR DESCRIPTION
# Summary

`\Braintree\WebhookTestingGateway::sampleNotification` needs to be a non-static method in order to access `$this->config` from the instantiated gateway passed to the `\Braintree\WebhookTestingGateway` constructor. The gateway config then needs to be used when creating the signature in `\Braintree\WebhookTestingGateway::sampleNotification`.

# Checklist

- [Yes] Added changelog entry
- [No] Ran unit tests (Check the README for instructions)
