### PR TITLE
Fix misspelling in Result\Successful->__toString function

### DIFF
--- a/lib/Braintree/Result/Successful.php
+++ b/lib/Braintree/Result/Successful.php
@@ -74,7 +74,7 @@ class Successful extends Instance
    {
        $objects = [];
        foreach ($this->_returnObjectNames as $returnObjectName) {
-           array_push($objects, $this->$returnObjectName);
+           array_push($objects, $returnObjectName);
        }
        return __CLASS__ . '[' . implode(', ', $objects) . ']';
    }


### PR DESCRIPTION
# Summary
In the Successful class the `__toString` function should use `$returnObjectName` instead of missing `$this->$returnObjectName` (`null`).
