### PR TITLE
Refer to fully qualified class names in PHPDoc

### DIFF
--- a/lib/Braintree/CustomerGateway.php
+++ b/lib/Braintree/CustomerGateway.php
@@ -80,7 +80,7 @@ class CustomerGateway
      *
      * @access public
      * @param array $attribs
-     * @return Braintree_Result_Successful|Braintree_Result_Error
+     * @return Result\Successful|Result\Error
      */
     public function create($attribs = [])
     {


### PR DESCRIPTION
Because this class is in `namespace Braintree;`, the old PHPDoc is referring to `\Braintree\Braintree_Result_Successful`, which doesn't exist. (`\Braintree_Result_Successful` does)

This would cause minor issues with IDE suggestions and static analyzers.

An alternate acceptable fix would be to change this to \Braintree_Result_Successful, but that isn't used elsewhere

These class references were defined by class_alias:

```
lib/Braintree/Result/Successful.php
92:class_alias('Braintree\Result\Successful', 'Braintree_Result_Successful');

lib/Braintree/Result/Error.php
123:class_alias('Braintree\Result\Error', 'Braintree_Result_Error');
```

# Summary

Fix nit on phpdoc, no impact is expected

# Checklist

- [ ] Added changelog entry
- [ ] Ran unit tests (Check the README for instructions)
