### PR TITLE
Updated continue statement inside a switch statement for compatibility with PHP 7.3

### DIFF
--- a/lib/Braintree/Util.php
+++ b/lib/Braintree/Util.php
@@ -99,7 +99,7 @@ class Util
 
             switch($error["extensions"]["errorClass"]) {
             case "VALIDATION":
-                continue;
+                continue 2;
             case "AUTHENTICATION":
                 throw new Exception\Authentication();
                 break;


### PR DESCRIPTION
As per php-src, '"continue" statements targeting "switch" control flow structures will now generate a warning' as of PHP 7.3.  [Ref](https://github.com/php/php-src/commit/04e3523b7d095341f65ed5e71a3cac82fca690e4)

PHP manual states that `continue 2` will continue with the next iteration of the outer loop. [Ref](http://php.net/manual/en/control-structures.continue.php)

This Pull Request updates the continue statement in lib/Braintree/Util.php for compatibility with PHP 7.3.
