### PR TITLE
Update unit tests for compatibility with PHPUnit 7.5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-xmlwriter": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "^7.5"
     },
     "autoload": {
         "psr-0": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,12 +2,12 @@
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="./vendor/autoload.php"
+         colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
 
     <php>
       <ini name="error_reporting" value="32767"/>

--- a/tests/Setup.php
+++ b/tests/Setup.php
@@ -11,12 +11,14 @@ require_once __DIR__ . '/Braintree/OAuthTestHelper.php';
 date_default_timezone_set('UTC');
 
 use Braintree\Configuration;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class Setup extends PHPUnit_Framework_TestCase
+class Setup extends TestCase
 {
-    public function __construct()
+    public function setUp()
     {
+        parent::setUp();
+        
         self::integrationMerchantConfig();
     }
 

--- a/tests/unit/AddressTest.php
+++ b/tests/unit/AddressTest.php
@@ -10,9 +10,12 @@ class AddressTest extends Setup
 {
     public function testGet_givesErrorIfInvalidProperty()
     {
-        $this->setExpectedException('PHPUnit_Framework_Error', 'Undefined property on Braintree\Address: foo');
+        $this->expectException('PHPUnit\Framework\Error\Error', 'Undefined property on Braintree\Address: foo');
+        
         $a = Braintree\Address::factory([]);
+
         $a->foo;
+        
     }
 
     public function testIsEqual()
@@ -55,25 +58,25 @@ class AddressTest extends Setup
 
     public function testFindErrorsOnBlankCustomerId()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\Address::find('', '123');
     }
 
     public function testFindErrorsOnBlankAddressId()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\Address::find('123', '');
     }
 
     public function testFindErrorsOnWhitespaceOnlyId()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\Address::find('123', '  ');
     }
 
     public function testFindErrorsOnWhitespaceOnlyCustomerId()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\Address::find('  ', '123');
     }
 }

--- a/tests/unit/ClientApi/ClientTokenTest.php
+++ b/tests/unit/ClientApi/ClientTokenTest.php
@@ -10,13 +10,13 @@ class ClientTokenTest extends Setup
 {
     public function testErrorsWhenCreditCardOptionsGivenWithoutCustomerId()
     {
-        $this->setExpectedException('InvalidArgumentException', 'invalid keys: options[makeDefault]');
+        $this->expectException('InvalidArgumentException', 'invalid keys: options[makeDefault]');
         Braintree\ClientToken::generate(["options" => ["makeDefault" => true]]);
     }
 
     public function testErrorsWhenInvalidArgumentIsSupplied()
     {
-        $this->setExpectedException('InvalidArgumentException', 'invalid keys: customrId');
+        $this->expectException('InvalidArgumentException', 'invalid keys: customrId');
         Braintree\ClientToken::generate(["customrId" => "1234"]);
     }
 }

--- a/tests/unit/ConfigurationTest.php
+++ b/tests/unit/ConfigurationTest.php
@@ -38,16 +38,14 @@ class ConfigurationTest extends Setup
         $this->assertTrue(TRUE);
     }
 
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage Configuration::publicKey needs to be set
-     */
     public function testAssertGlobalHasAccessTokenOrKeysWithoutPublicKey()
     {
         Braintree\Configuration::environment('development');
         Braintree\Configuration::merchantId('integration_merchant_id');
         Braintree\Configuration::publicKey('');
         Braintree\Configuration::privateKey('integration_private_key');
+
+        $this->expectException('Braintree\Exception\Configuration', 'Configuration::publicKey needs to be set');
 
         Braintree\Configuration::assertGlobalHasAccessTokenOrKeys();
     }
@@ -76,13 +74,12 @@ class ConfigurationTest extends Setup
         Braintree\Configuration::reset();
     }
 
-    /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage "invalid" is not a valid environment.
-     */
     public function testSetInvalidEnvironment()
     {
+        $this->expectException('Braintree\Exception\Configuration', '"invalid" is not a valid environment.');
+        
         Braintree\Configuration::environment('invalid');
+
         Braintree\Configuration::reset();
     }
 
@@ -96,7 +93,7 @@ class ConfigurationTest extends Setup
     public function testCaFile()
     {
         $this->config->setEnvironment('development');
-        $this->setExpectedException('Braintree\Exception\SSLCaFileNotFound');
+        $this->expectException('Braintree\Exception\SSLCaFileNotFound');
         $this->config->caFile('/does/not/exist/');
     }
 
@@ -281,10 +278,6 @@ class ConfigurationTest extends Setup
         $this->assertFalse($this->config->acceptGzipEncoding());
     }
 
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage environment needs to be set
-     */
     public function testValidateAbsentEnvironment()
     {
         //Braintree\Configuration::environment('development');
@@ -292,12 +285,11 @@ class ConfigurationTest extends Setup
         Braintree\Configuration::publicKey('integration_public_key');
         Braintree\Configuration::privateKey('integration_private_key');
 
+        $this->expectException('Braintree\Exception\Configuration', 'environment needs to be set');
+
         Braintree\Configuration::$global->assertHasAccessTokenOrKeys();
     }
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage environment needs to be set
-     */
+
     public function testValidateEmptyStringEnvironment()
     {
         Braintree\Configuration::environment('');
@@ -305,12 +297,11 @@ class ConfigurationTest extends Setup
         Braintree\Configuration::publicKey('integration_public_key');
         Braintree\Configuration::privateKey('integration_private_key');
 
+        $this->expectException('Braintree\Exception\Configuration', 'environment needs to be set');
+
         Braintree\Configuration::$global->assertHasAccessTokenOrKeys();
     }
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage merchantId needs to be set
-     */
+
     public function testAbsentMerchantId()
     {
         Braintree\Configuration::environment('development');
@@ -318,12 +309,11 @@ class ConfigurationTest extends Setup
         Braintree\Configuration::publicKey('integration_public_key');
         Braintree\Configuration::privateKey('integration_private_key');
 
+        $this->expectException('Braintree\Exception\Configuration', 'merchantId needs to be set');
+
         Braintree\Configuration::$global->assertHasAccessTokenOrKeys();
     }
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage merchantId needs to be set
-     */
+
     public function testEmptyStringMerchantId()
     {
         Braintree\Configuration::environment('development');
@@ -331,12 +321,11 @@ class ConfigurationTest extends Setup
         Braintree\Configuration::publicKey('integration_public_key');
         Braintree\Configuration::privateKey('integration_private_key');
 
+        $this->expectException('Braintree\Exception\Configuration', 'merchantId needs to be set');
+
         Braintree\Configuration::$global->assertHasAccessTokenOrKeys();
     }
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage publicKey needs to be set
-     */
+
     public function testAbsentPublicKey()
     {
         Braintree\Configuration::environment('development');
@@ -344,12 +333,11 @@ class ConfigurationTest extends Setup
         //Braintree\Configuration::publicKey('integration_public_key');
         Braintree\Configuration::privateKey('integration_private_key');
 
+        $this->expectException('Braintree\Exception\Configuration', 'publicKey needs to be set');
+
         Braintree\Configuration::$global->assertHasAccessTokenOrKeys();
     }
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage publicKey needs to be set
-     */
+
     public function testEmptyStringPublicKey()
     {
         Braintree\Configuration::environment('development');
@@ -357,12 +345,11 @@ class ConfigurationTest extends Setup
         Braintree\Configuration::publicKey('');
         Braintree\Configuration::privateKey('integration_private_key');
 
+        $this->expectException('Braintree\Exception\Configuration', 'publicKey needs to be set');
+
         Braintree\Configuration::$global->assertHasAccessTokenOrKeys();
     }
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage privateKey needs to be set
-     */
+
     public function testAbsentPrivateKey()
     {
         Braintree\Configuration::environment('development');
@@ -370,18 +357,19 @@ class ConfigurationTest extends Setup
         Braintree\Configuration::publicKey('integration_public_key');
         //Braintree\Configuration::privateKey('integration_private_key');
 
+        $this->expectException('Braintree\Exception\Configuration', 'privateKey needs to be set');
+
         Braintree\Configuration::$global->assertHasAccessTokenOrKeys();
     }
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage privateKey needs to be set
-     */
+
     public function testEmptyStringPrivateKey()
     {
         Braintree\Configuration::environment('development');
         Braintree\Configuration::merchantId('integration_merchant_id');
         Braintree\Configuration::publicKey('integration_public_key');
         Braintree\Configuration::privateKey('');
+
+        $this->expectException('Braintree\Exception\Configuration', 'privateKey needs to be set');
 
         Braintree\Configuration::$global->assertHasAccessTokenOrKeys();
     }
@@ -393,18 +381,16 @@ class ConfigurationTest extends Setup
             'clientSecret' => 'client_secret$development$integration_client_secret'
         ]);
 
-        $config->assertHasClientCredentials();
+        $this->assertNull($config->assertHasClientCredentials());
     }
 
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage clientSecret needs to be passed
-     */
     public function testInvalidWithOAuthClientCredentials()
     {
         $config = new Braintree\Configuration([
             'clientId' => 'client_id$development$integration_client_id'
         ]);
+
+        $this->expectException('Braintree\Exception\Configuration', 'clientSecret needs to be passed');
 
         $config->assertHasClientCredentials();
     }
@@ -419,24 +405,20 @@ class ConfigurationTest extends Setup
         $this->assertEquals('development', $config->getEnvironment());
     }
 
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage Mismatched credential environments: clientId environment is sandbox and clientSecret environment is development
-     */
     public function testDetectEnvironmentFromClientIdFail()
     {
+        $this->expectException('Braintree\Exception\Configuration', 'Mismatched credential environments: clientId environment is sandbox and clientSecret environment is development');
+        
         $config = new Braintree\Configuration([
             'clientId' => 'client_id$sandbox$integration_client_id',
             'clientSecret' => 'client_secret$development$integration_client_secret'
         ]);
     }
 
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage Value passed for clientId is not a clientId
-     */
     public function testClientIdTypeFail()
     {
+        $this->expectException('Braintree\Exception\Configuration', 'Value passed for clientId is not a clientId');
+        
         $config = new Braintree\Configuration([
             'clientId' => 'client_secret$development$integration_client_id',
             'clientSecret' => 'client_secret$development$integration_client_secret'
@@ -449,37 +431,31 @@ class ConfigurationTest extends Setup
             'accessToken' => 'access_token$development$integration_merchant_id$integration_access_token',
         ]);
 
-        $config->assertHasAccessTokenOrKeys();
+        $this->assertNull($config->assertHasAccessTokenOrKeys());
     }
 
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage Value passed for accessToken is not an accessToken
-     */
     public function testInvalidAccessTokenType()
     {
+        $this->expectException('Braintree\Exception\Configuration', 'Value passed for accessToken is not an accessToken');
+        
         $config = new Braintree\Configuration([
             'accessToken' => 'client_id$development$integration_merchant_id$integration_access_token',
         ]);
     }
 
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage Incorrect accessToken syntax. Expected: type$environment$merchant_id$token
-     */
     public function testInvalidAccessTokenSyntax()
     {
+        $this->expectException('Braintree\Exception\Configuration', 'Incorrect accessToken syntax. Expected: type$environment$merchant_id$token');
+        
         $config = new Braintree\Configuration([
             'accessToken' => 'client_id$development$integration_client_id',
         ]);
     }
 
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage "invalid" is not a valid environment.
-     */
     public function testInvalidAccessTokenEnvironment()
     {
+        $this->expectException('Braintree\Exception\Configuration', '"invalid" is not a valid environment.');
+        
         $config = new Braintree\Configuration([
             'accessToken' => 'access_token$invalid$integration_merchant_id$integration_access_token',
         ]);
@@ -494,16 +470,14 @@ class ConfigurationTest extends Setup
             'accessToken' => 'access_token$development$integration_merchant_id$integration_access_token',
         ]);
 
-        $config->assertHasClientCredentials();
-        $config->assertHasAccessTokenOrKeys();
+        $this->assertNull($config->assertHasClientCredentials());
+        $this->assertNull($config->assertHasAccessTokenOrKeys());
     }
 
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage Mismatched credential environments: clientId environment is development and accessToken environment is sandbox
-     */
     public function testInvalidEnvironmentWithOAuthClientCredentialsAndAccessToken()
     {
+        $this->expectException('Braintree\Exception\Configuration', 'Mismatched credential environments: clientId environment is development and accessToken environment is sandbox');
+        
         $config = new Braintree\Configuration([
             'clientId' => 'client_id$development$integration_client_id',
             'clientSecret' => 'client_secret$development$integration_client_secret',
@@ -511,12 +485,10 @@ class ConfigurationTest extends Setup
         ]);
     }
 
-     /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage Cannot mix OAuth credentials (clientId, clientSecret, accessToken) with key credentials (publicKey, privateKey, environment, merchantId)
-     */
     public function testCannotMixKeysWithOAuthCredentials()
     {
+        $this->expectException('Braintree\Exception\Configuration', 'Cannot mix OAuth credentials (clientId, clientSecret, accessToken) with key credentials (publicKey, privateKey, environment, merchantId)');
+        
         $config = new Braintree\Configuration([
             'clientId' => 'client_id$development$integration_client_id',
             'clientSecret' => 'client_secret$development$integration_client_secret',

--- a/tests/unit/CreditCardTest.php
+++ b/tests/unit/CreditCardTest.php
@@ -11,14 +11,14 @@ class CreditCardTest extends Setup
 {
     public function testGet_givesErrorIfInvalidProperty()
     {
-        $this->setExpectedException('PHPUnit_Framework_Error', 'Undefined property on Braintree\CreditCard: foo');
+        $this->expectException('PHPUnit\Framework\Error\Error', 'Undefined property on Braintree\CreditCard: foo');
         $cc = Braintree\CreditCard::factory([]);
         $cc->foo;
     }
 
     public function testCreate_throwsIfInvalidKey()
     {
-        $this->setExpectedException('InvalidArgumentException', 'invalid keys: invalidKey');
+        $this->expectException('InvalidArgumentException', 'invalid keys: invalidKey');
         Braintree\CreditCard::create(['invalidKey' => 'foo']);
     }
 
@@ -108,19 +108,19 @@ class CreditCardTest extends Setup
 
     public function testErrorsOnFindWithBlankArgument()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\CreditCard::find('');
     }
 
     public function testErrorsOnFindWithWhitespaceArgument()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\CreditCard::find('  ');
     }
 
     public function testErrorsOnFindWithWhitespaceCharacterArgument()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\CreditCard::find('\t');
     }
 

--- a/tests/unit/CreditCardVerificationTest.php
+++ b/tests/unit/CreditCardVerificationTest.php
@@ -10,13 +10,13 @@ class CreditCardVerificationTest extends Setup
 {
 	public function test_createWithInvalidArguments()
 	{
-        $this->setExpectedException('InvalidArgumentException', 'invalid keys: invalidProperty');
+        $this->expectException('InvalidArgumentException', 'invalid keys: invalidProperty');
 		Braintree\CreditCardVerification::create(['options' => ['amount' => '123.45'], 'invalidProperty' => 'foo']);
 	}
 
 	public function test_createWithPaymentMethodArguments()
 	{
-        $this->setExpectedException('InvalidArgumentException', 'invalid keys: creditCard[venmoSdkPaymentMethodCode]');
+        $this->expectException('InvalidArgumentException', 'invalid keys: creditCard[venmoSdkPaymentMethodCode]');
 		Braintree\CreditCardVerification::create(['options' => ['amount' => '123.45'], 'creditCard' => ['venmoSdkPaymentMethodCode' => 'foo']]);
 	}
 }

--- a/tests/unit/CustomerTest.php
+++ b/tests/unit/CustomerTest.php
@@ -10,7 +10,7 @@ class CustomerTest extends Setup
 {
     public function testGet_givesErrorIfInvalidProperty()
     {
-        $this->setExpectedException('PHPUnit_Framework_Error', 'Undefined property on Braintree\Customer: foo');
+        $this->expectException('PHPUnit\Framework\Error\Error', 'Undefined property on Braintree\Customer: foo');
         $c = Braintree\Customer::factory([]);
         $c->foo;
     }
@@ -48,13 +48,13 @@ class CustomerTest extends Setup
 
     public function testFindErrorsOnBlankId()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\Customer::find('');
     }
 
     public function testFindErrorsOnWhitespaceId()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\Customer::find('\t');
     }
 }

--- a/tests/unit/DisputeTest.php
+++ b/tests/unit/DisputeTest.php
@@ -11,7 +11,10 @@ class DisputeTest extends Setup
 {
     private $attributes;
 
-    public function __construct() {
+    public function setUp() {
+        
+        parent::setUp();
+        
         $this->attributes = [
             'amount' => '100.00',
             'amountDisputed' => '100.00',
@@ -188,49 +191,49 @@ class DisputeTest extends Setup
 
     public function testAcceptNullRaisesNotFoundException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'dispute with id "" not found');
+        $this->expectException('Braintree\Exception\NotFound', 'dispute with id "" not found');
 
         Braintree\Dispute::accept(null);
     }
 
 	public function testAcceptEmptyIdRaisesNotFoundException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'dispute with id " " not found');
+        $this->expectException('Braintree\Exception\NotFound', 'dispute with id " " not found');
 
         Braintree\Dispute::accept(" ");
     }
 
 	public function testAddTextEvidenceEmptyIdRaisesNotFoundException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'dispute with id " " not found');
+        $this->expectException('Braintree\Exception\NotFound', 'dispute with id " " not found');
 
         Braintree\Dispute::addTextEvidence(" ", "evidence");
     }
 
 	public function testAddTextEvidenceNullIdRaisesNotFoundException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'dispute with id "" not found');
+        $this->expectException('Braintree\Exception\NotFound', 'dispute with id "" not found');
 
         Braintree\Dispute::addTextEvidence(null, "evidence");
     }
 
 	public function testAddTextEvidenceEmptyEvidenceRaisesValueException()
     {
-        $this->setExpectedException('InvalidArgumentException', 'content cannot be blank');
+        $this->expectException('InvalidArgumentException', 'content cannot be blank');
 
         Braintree\Dispute::addTextEvidence("disputeId", " ");
     }
 
 	public function testAddTextEvidenceNullEvidenceRaisesValueException()
     {
-        $this->setExpectedException('InvalidArgumentException', 'content cannot be blank');
+        $this->expectException('InvalidArgumentException', 'content cannot be blank');
 
         Braintree\Dispute::addTextEvidence("disputeId", null);
     }
 
 	public function testAddTextEvidenceBlankRequestContentRaisesValueException()
     {
-        $this->setExpectedException('InvalidArgumentException', 'content cannot be blank');
+        $this->expectException('InvalidArgumentException', 'content cannot be blank');
 
         Braintree\Dispute::addTextEvidence("disputeId",
             [
@@ -243,7 +246,7 @@ class DisputeTest extends Setup
 
 	public function testAddTextEvidenceNullRequestContentRaisesValueException()
     {
-        $this->setExpectedException('InvalidArgumentException', 'content cannot be blank');
+        $this->expectException('InvalidArgumentException', 'content cannot be blank');
 
         Braintree\Dispute::addTextEvidence("disputeId",
             [
@@ -256,7 +259,7 @@ class DisputeTest extends Setup
 
 	public function testAddTextEvidenceBlankRequestCategoryRaisesValueException()
     {
-        $this->setExpectedException('InvalidArgumentException', 'category cannot be blank');
+        $this->expectException('InvalidArgumentException', 'category cannot be blank');
 
         Braintree\Dispute::addTextEvidence("disputeId",
             [
@@ -269,7 +272,7 @@ class DisputeTest extends Setup
 
 	public function testAddTextEvidenceBlankRequestSequenceNumberRaisesValueException()
     {
-        $this->setExpectedException('InvalidArgumentException', 'sequenceNumber cannot be blank');
+        $this->expectException('InvalidArgumentException', 'sequenceNumber cannot be blank');
 
         Braintree\Dispute::addTextEvidence("disputeId",
             [
@@ -282,7 +285,7 @@ class DisputeTest extends Setup
 
 	public function testAddTextEvidenceNonIntegerNumberRequestSequenceNumberRaisesValueException()
     {
-        $this->setExpectedException('InvalidArgumentException', 'sequenceNumber must be an int');
+        $this->expectException('InvalidArgumentException', 'sequenceNumber must be an int');
 
         Braintree\Dispute::addTextEvidence("disputeId",
             [
@@ -295,7 +298,7 @@ class DisputeTest extends Setup
 
 	public function testAddTextEvidenceNonIntegerStringRequestSequenceNumberRaisesValueException()
     {
-        $this->setExpectedException('InvalidArgumentException', 'sequenceNumber must be an int');
+        $this->expectException('InvalidArgumentException', 'sequenceNumber must be an int');
 
         Braintree\Dispute::addTextEvidence("disputeId",
             [
@@ -308,35 +311,35 @@ class DisputeTest extends Setup
 
     public function testAddFileEvidenceEmptyIdRaisesNotFoundException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'dispute with id " " not found');
+        $this->expectException('Braintree\Exception\NotFound', 'dispute with id " " not found');
 
         Braintree\Dispute::addFileEvidence(" ", 1);
     }
 
     public function testAddFileEvidenceNullIdRaisesNotFoundException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'dispute with id "" not found');
+        $this->expectException('Braintree\Exception\NotFound', 'dispute with id "" not found');
 
         Braintree\Dispute::addFileEvidence(null, 1);
     }
 
     public function testAddFileEvidenceEmptyEvidenceRaisesValueException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'document with id " " not found');
+        $this->expectException('Braintree\Exception\NotFound', 'document with id " " not found');
 
         Braintree\Dispute::addFileEvidence("disputeId", " ");
     }
 
     public function testAddFileEvidenceNullEvidenceRaisesValueException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'document with id "" not found');
+        $this->expectException('Braintree\Exception\NotFound', 'document with id "" not found');
 
         Braintree\Dispute::addFileEvidence("disputeId", null);
     }
 
     public function testAddFileEvidenceBlankRequestContentRaisesValueException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'document with id " " not found');
+        $this->expectException('Braintree\Exception\NotFound', 'document with id " " not found');
 
         Braintree\Dispute::addFileEvidence("disputeId",
             [
@@ -348,7 +351,7 @@ class DisputeTest extends Setup
 
     public function testAddFileEvidenceNullRequestContentRaisesValueException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'document with id "" not found');
+        $this->expectException('Braintree\Exception\NotFound', 'document with id "" not found');
 
         Braintree\Dispute::addFileEvidence("disputeId",
             [
@@ -360,7 +363,7 @@ class DisputeTest extends Setup
 
     public function testAddFileEvidenceBlankRequestCategoryRaisesValueException()
     {
-        $this->setExpectedException('InvalidArgumentException', 'category cannot be blank');
+        $this->expectException('InvalidArgumentException', 'category cannot be blank');
 
         Braintree\Dispute::addFileEvidence("disputeId",
             [
@@ -372,56 +375,56 @@ class DisputeTest extends Setup
 
 	public function testFinalizeNullRaisesNotFoundException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'dispute with id "" not found');
+        $this->expectException('Braintree\Exception\NotFound', 'dispute with id "" not found');
 
         Braintree\Dispute::finalize(null);
     }
 
 	public function testFinalizeEmptyIdRaisesNotFoundException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'dispute with id " " not found');
+        $this->expectException('Braintree\Exception\NotFound', 'dispute with id " " not found');
 
         Braintree\Dispute::finalize(" ");
     }
 
 	public function testFindingNullRaisesNotFoundException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'dispute with id "" not found');
+        $this->expectException('Braintree\Exception\NotFound', 'dispute with id "" not found');
 
         Braintree\Dispute::find(null);
     }
 
 	public function testFindingEmptyIdRaisesNotFoundException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'dispute with id " " not found');
+        $this->expectException('Braintree\Exception\NotFound', 'dispute with id " " not found');
 
         Braintree\Dispute::find(" ");
     }
 
 	public function testRemoveEvidenceEmptyDisputeIdRaisesNotFoundException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'evidence with id "evidence" for dispute with id " " not found');
+        $this->expectException('Braintree\Exception\NotFound', 'evidence with id "evidence" for dispute with id " " not found');
 
         Braintree\Dispute::removeEvidence(" ", "evidence");
     }
 
 	public function testRemoveEvidenceNullDisputeIdRaisesNotFoundException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'evidence with id "evidence" for dispute with id "" not found');
+        $this->expectException('Braintree\Exception\NotFound', 'evidence with id "evidence" for dispute with id "" not found');
 
         Braintree\Dispute::removeEvidence(null, "evidence");
     }
 
 	public function testRemoveEvidenceEvidenceNullIdRaisesNotFoundException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'evidence with id "" for dispute with id "dispute_id" not found');
+        $this->expectException('Braintree\Exception\NotFound', 'evidence with id "" for dispute with id "dispute_id" not found');
 
         Braintree\Dispute::removeEvidence("dispute_id", null);
     }
 
 	public function testRemoveEvidenceEmptyEvidenceIdRaisesValueException()
     {
-        $this->setExpectedException('Braintree\Exception\NotFound', 'evidence with id " " for dispute with id "dispute_id" not found');
+        $this->expectException('Braintree\Exception\NotFound', 'evidence with id " " for dispute with id "dispute_id" not found');
 
         Braintree\Dispute::removeEvidence("dispute_id", " ");
     }

--- a/tests/unit/DocumentUploadTest.php
+++ b/tests/unit/DocumentUploadTest.php
@@ -13,7 +13,7 @@ class DocumentUploadTest extends Setup
      */
     public function testCreateThrowsExceptionWithBadKeys()
     {
-        $this->setExpectedException('InvalidArgumentException', 'invalid keys: bad_key');
+        $this->expectException('InvalidArgumentException', 'invalid keys: bad_key');
 
         Braintree\DocumentUpload::create(["bad_key" => "value"]);
     }

--- a/tests/unit/GatewayTest.php
+++ b/tests/unit/GatewayTest.php
@@ -21,10 +21,6 @@ class GatewayTest extends Setup
         Braintree\Configuration::privateKey('integration_private_key');
     }
 
-    /**
-     * @expectedException Braintree\Exception\Configuration
-    * @expectedExceptionMessage needs to be set (or accessToken needs to be passed to Braintree\Gateway).
-     */
     public function testConfigGetsAssertedValid()
     {
         Braintree\Configuration::environment('development');
@@ -33,6 +29,8 @@ class GatewayTest extends Setup
         Braintree\Configuration::privateKey('integration_private_key');
 
         $gateway = new Braintree\Gateway(Braintree\Configuration::$global);
+
+        $this->expectException('Braintree\Exception\Configuration', 'needs to be set (or accessToken needs to be passed to Braintree\Gateway).');
         $gateway->addOn();
     }
 

--- a/tests/unit/HttpTest.php
+++ b/tests/unit/HttpTest.php
@@ -12,7 +12,7 @@ class HttpTest extends Setup
     {
         try {
             Braintree\Configuration::environment('development');
-            $this->setExpectedException('Braintree\Exception\Connection', null, 3);
+            $this->expectException('Braintree\Exception\Connection', null, 3);
             $http = new Braintree\Http(Braintree\Configuration::$global);
             $http->_doUrlRequest('get', '/a_malformed_url');
         } catch (Braintree\Exception $e) {
@@ -24,7 +24,7 @@ class HttpTest extends Setup
     {
         try {
             Braintree\Configuration::environment('sandbox');
-            $this->setExpectedException('Braintree\Exception\SSLCertificate', null, 3);
+            $this->expectException('Braintree\Exception\SSLCertificate', null, 3);
             $http = new Braintree\Http(Braintree\Configuration::$global);
             $http->_doUrlRequest('get', '/a_malformed_url_using_ssl');
         } catch (Braintree\Exception $e) {
@@ -39,7 +39,7 @@ class HttpTest extends Setup
         try {
             Braintree\Configuration::environment('sandbox');
             Braintree\Configuration::sslVersion(3);
-            $this->setExpectedException('Braintree\Exception\SSLCertificate', null, 35);
+            $this->expectException('Braintree\Exception\SSLCertificate', null, 35);
             $http = new Braintree\Http(Braintree\Configuration::$global);
             $http->get('/');
         } catch (Braintree\Exception $e) {
@@ -55,6 +55,9 @@ class HttpTest extends Setup
     {
         Braintree\Configuration::environment('development');
         $http = new Braintree\Http(Braintree\Configuration::$global);
-        $http->_doUrlRequest('get', 'http://example.com');
+        $response = $http->_doUrlRequest('get', 'http://example.com');
+
+        //example.com returns HTTP 501 response code because it does not recognize the Braintree user agent.  This is expected behavior.
+        $this->assertEquals(501, $response['status']);
     }
 }

--- a/tests/unit/PayPalAccountTest.php
+++ b/tests/unit/PayPalAccountTest.php
@@ -10,7 +10,7 @@ class PayPalAccountTest extends Setup
 {
     public function testGet_givesErrorIfInvalidProperty()
     {
-        $this->setExpectedException('PHPUnit_Framework_Error', 'Undefined property on Braintree\PayPalAccount: foo');
+        $this->expectException('PHPUnit\Framework\Error\Error', 'Undefined property on Braintree\PayPalAccount: foo');
         $paypalAccount = Braintree\PayPalAccount::factory([]);
         $paypalAccount->foo;
     }
@@ -26,19 +26,19 @@ class PayPalAccountTest extends Setup
 
     public function testErrorsOnFindWithBlankArgument()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\PayPalAccount::find('');
     }
 
     public function testErrorsOnFindWithWhitespaceArgument()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\PayPalAccount::find('  ');
     }
 
     public function testErrorsOnFindWithWhitespaceCharacterArgument()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\PayPalAccount::find('\t');
     }
 }

--- a/tests/unit/PaymentMethodTest.php
+++ b/tests/unit/PaymentMethodTest.php
@@ -10,7 +10,7 @@ class PaymentMethodTest extends Setup
 {
     public function testCreate_throwsIfInvalidKey()
     {
-        $this->setExpectedException('InvalidArgumentException', 'invalid keys: invalidKey');
+        $this->expectException('InvalidArgumentException', 'invalid keys: invalidKey');
         Braintree\PaymentMethod::create(['invalidKey' => 'foo']);
     }
 
@@ -62,19 +62,19 @@ class PaymentMethodTest extends Setup
 
     public function testErrorsOnFindWithBlankArgument()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\PaymentMethod::find('');
     }
 
     public function testErrorsOnFindWithWhitespaceArgument()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\PaymentMethod::find('  ');
     }
 
     public function testErrorsOnFindWithWhitespaceCharacterArgument()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\PaymentMethod::find('\t');
     }
 
@@ -105,7 +105,7 @@ class PaymentMethodTest extends Setup
     public function testDeleteWithInvalidOption()
     {
         $paymentMethodGateway = $this->mockPaymentMethodGatewayDoDelete();
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $paymentMethodGateway->expects($this->never())->method('_doDelete');
         $paymentMethodGateway->delete("some_token", ['invalidKey' => false]);
     }

--- a/tests/unit/Result/SuccessfulTest.php
+++ b/tests/unit/Result/SuccessfulTest.php
@@ -8,14 +8,14 @@ use Braintree;
 
 class SuccessfulTest extends Setup
 {
-     /**
-     * @expectedException        PHPUnit_Framework_Error_Notice
-     * @expectedExceptionMessage Undefined property on Braintree\Result\Successful: notAProperty
-     */
     public function testCallingNonExsitingFieldReturnsNull()
     {
+        $this->expectException('PHPUnit\Framework\Error\Notice');
+        $this->expectExceptionMessage('Undefined property on Braintree\Result\Successful: notAProperty');
+        
         $result = new Braintree\Result\Successful(1, 'transaction');
+
         $this->assertNotNull($result->transaction);
-        $this->assertNull($result->notAProperty);
+        $this->assertNull($result->notAProperty);     
     }
 }

--- a/tests/unit/SubscriptionTest.php
+++ b/tests/unit/SubscriptionTest.php
@@ -10,13 +10,13 @@ class SubscriptionTest extends Setup
 {
     public function testErrorsOnFindWithBlankArgument()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\Subscription::find('');
     }
 
     public function testErrorsOnFindWithWhitespaceArgument()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\Subscription::find('\t');
     }
 }

--- a/tests/unit/TransactionTest.php
+++ b/tests/unit/TransactionTest.php
@@ -19,25 +19,25 @@ class TransactionTest extends Setup
             'subscription' => ['billingPeriodStartDate' => '1983-07-12'],
             'statusHistory' => []
         ]);
-        $this->setExpectedException('PHPUnit_Framework_Error', 'Undefined property on Braintree\Transaction: foo');
+        $this->expectException('PHPUnit\Framework\Error\Error', 'Undefined property on Braintree\Transaction: foo');
         $t->foo;
     }
 
     public function testCloneTransaction_RaisesErrorOnInvalidProperty()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\Transaction::cloneTransaction('an id', ['amount' => '123.45', 'invalidProperty' => 'foo']);
     }
 
     public function testErrorsWhenFindWithBlankString()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\Transaction::find('');
     }
 
     public function testErrorsWhenFindWithWhitespaceString()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\Transaction::find('\t');
     }
 

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -10,73 +10,62 @@ use Braintree;
 
 class UtilTest extends Setup
 {
-    /**
-     * @expectedException Braintree\Exception\Authentication
-     */
     public function testThrow401Exception()
     {
+        $this->expectException('Braintree\Exception\Authentication');
+        
         Braintree\Util::throwStatusCodeException(401);
     }
 
-    /**
-     * @expectedException Braintree\Exception\Authorization
-     */
     public function testThrow403Exception()
     {
+        $this->expectException('Braintree\Exception\Authorization');
+        
         Braintree\Util::throwStatusCodeException(403);
     }
 
-    /**
-     * @expectedException Braintree\Exception\NotFound
-     */
     public function testThrow404Exception()
     {
+        $this->expectException('Braintree\Exception\NotFound');
+        
         Braintree\Util::throwStatusCodeException(404);
     }
 
-    /**
-     * @expectedException Braintree\Exception\UpgradeRequired
-     */
     public function testThrow426Exception()
     {
+        $this->expectException('Braintree\Exception\UpgradeRequired');
+        
         Braintree\Util::throwStatusCodeException(426);
     }
 
-    /**
-     * @expectedException Braintree\Exception\TooManyRequests
-     */
     public function testThrow429Exception()
     {
+        $this->expectException('Braintree\Exception\TooManyRequests');
+        
         Braintree\Util::throwStatusCodeException(429);
     }
 
-    /**
-     * @expectedException Braintree\Exception\ServerError
-     */
     public function testThrow500Exception()
     {
+        $this->expectException('Braintree\Exception\ServerError');
+        
         Braintree\Util::throwStatusCodeException(500);
     }
 
-    /**
-     * @expectedException Braintree\Exception\DownForMaintenance
-     */
     public function testThrow503Exception()
     {
+        $this->expectException('Braintree\Exception\DownForMaintenance');
+        
         Braintree\Util::throwStatusCodeException(503);
     }
 
-    /**
-     * @expectedException Braintree\Exception\Unexpected
-     */
     public function testThrowUnknownException()
     {
+        $this->expectException('Braintree\Exception\Unexpected');
+        
         Braintree\Util::throwStatusCodeException(999);
     }
 
-    /**
-     * @expectedException Braintree\Exception\Authentication
-     */
     public function testThrowGraphQLAuthenticationException()
     {
         $response = [
@@ -89,12 +78,12 @@ class UtilTest extends Setup
                 ]
             ]
         ];
+
+        $this->expectException('Braintree\Exception\Authentication');
+
         Braintree\Util::throwGraphQLResponseException($response);
     }
 
-    /**
-     * @expectedException Braintree\Exception\Authorization
-     */
     public function testThrowGraphQLAuthorizationException()
     {
         $response = [
@@ -107,12 +96,12 @@ class UtilTest extends Setup
                 ]
             ]
         ];
+
+        $this->expectException('Braintree\Exception\Authorization');
+
         Braintree\Util::throwGraphQLResponseException($response);
     }
 
-    /**
-     * @expectedException Braintree\Exception\NotFound
-     */
     public function testThrowGraphQLNotFoundException()
     {
         $response = [
@@ -125,12 +114,12 @@ class UtilTest extends Setup
                 ]
             ]
         ];
+
+        $this->expectException('Braintree\Exception\NotFound');
+
         Braintree\Util::throwGraphQLResponseException($response);
     }
 
-    /**
-     * @expectedException Braintree\Exception\UpgradeRequired
-     */
     public function testThrowGraphQLUnsupportedClientException()
     {
         $response = [
@@ -143,12 +132,12 @@ class UtilTest extends Setup
                 ]
             ]
         ];
+
+        $this->expectException('Braintree\Exception\UpgradeRequired');
+
         Braintree\Util::throwGraphQLResponseException($response);
     }
 
-    /**
-     * @expectedException Braintree\Exception\TooManyRequests
-     */
     public function testThrowGraphQLResourceLimitException()
     {
         $response = [
@@ -161,12 +150,12 @@ class UtilTest extends Setup
                 ]
             ]
         ];
+
+        $this->expectException('Braintree\Exception\TooManyRequests');
+
         Braintree\Util::throwGraphQLResponseException($response);
     }
 
-    /**
-     * @expectedException Braintree\Exception\ServerError
-     */
     public function testThrowGraphQLInternalException()
     {
         $response = [
@@ -179,12 +168,12 @@ class UtilTest extends Setup
                 ]
             ]
         ];
+
+        $this->expectException('Braintree\Exception\ServerError');
+
         Braintree\Util::throwGraphQLResponseException($response);
     }
 
-    /**
-     * @expectedException Braintree\Exception\DownForMaintenance
-     */
     public function testThrowGraphQLServiceAvailabilityException()
     {
         $response = [
@@ -197,12 +186,12 @@ class UtilTest extends Setup
                 ]
             ]
         ];
+
+        $this->expectException('Braintree\Exception\DownForMaintenance');
+
         Braintree\Util::throwGraphQLResponseException($response);
     }
 
-    /**
-     * @expectedException Braintree\Exception\Unexpected
-     */
     public function testThrowGraphQLUnexpectedException()
     {
         $response = [
@@ -215,6 +204,9 @@ class UtilTest extends Setup
                 ]
             ]
         ];
+
+        $this->expectException('Braintree\Exception\Unexpected');
+
         Braintree\Util::throwGraphQLResponseException($response);
     }
 
@@ -230,12 +222,10 @@ class UtilTest extends Setup
                 ]
             ]
         ];
-        Braintree\Util::throwGraphQLResponseException($response);
+        $this->assertNull(Braintree\Util::throwGraphQLResponseException($response));
+        
     }
 
-    /**
-     * @expectedException Braintree\Exception\Unexpected
-     */
     public function testThrowGraphQLUnexpectedExceptionAndNotValidationExceptionWhenBothArePresent()
     {
         $response = [
@@ -254,6 +244,9 @@ class UtilTest extends Setup
                 ]
             ]
         ];
+
+        $this->expectException('Braintree\Exception\Unexpected');
+
         Braintree\Util::throwGraphQLResponseException($response);
     }
 
@@ -319,7 +312,7 @@ class UtilTest extends Setup
                 ]
             ]
         ];
-        Braintree\Util::verifyKeys($signature, $data);
+        $this->assertNull(Braintree\Util::verifyKeys($signature, $data));
     }
 
 	public function testVerifyKeys_withArrayOfArrays()
@@ -355,7 +348,7 @@ class UtilTest extends Setup
             ]
 		];
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\Util::verifyKeys($signature, $badData);
 	}
 
@@ -363,7 +356,7 @@ class UtilTest extends Setup
     {
         $signature = ['key'];
         $data = ['key' => ['value']];
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         Braintree\Util::verifyKeys($signature, $data);
     }
 
@@ -428,17 +421,17 @@ class UtilTest extends Setup
                 ];
 
         // test invalid
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         Braintree\Util::verifyKeys($signature, $userKeys);
     }
 
-    /**
-     * @expectedException Braintree\Exception\ValidationsFailed
-     */
     public function testReturnException()
     {
         $this->success = false;
+
+        $this->expectException('Braintree\Exception\ValidationsFailed');
+
         Braintree\Util::returnObjectOrThrowException('Braintree\Transaction', $this);
     }
 

--- a/tests/unit/WebhookNotificationTest.php
+++ b/tests/unit/WebhookNotificationTest.php
@@ -20,24 +20,18 @@ class WebhookNotificationTest extends Setup
         $this->assertEquals('integration_public_key|d9b899556c966b3f06945ec21311865d35df3ce4', $verificationString);
     }
 
-    /**
-     * @expectedException Braintree\Exception\InvalidChallenge
-     * @expectedExceptionMessage challenge contains non-hex characters
-     */
     public function testVerifyRaisesErrorWithInvalidChallenge()
     {
-        $this->setExpectedException('Braintree\Exception\InvalidChallenge', 'challenge contains non-hex characters');
+        $this->expectException('Braintree\Exception\InvalidChallenge', 'challenge contains non-hex characters');
 
         Braintree\WebhookNotification::verify('bad challenge');
     }
 
-    /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage Braintree\Configuration::merchantId needs to be set (or accessToken needs to be passed to Braintree\Gateway)
-     */
     public function testVerifyRaisesErrorWhenEnvironmentNotSet()
     {
         Braintree\Configuration::reset();
+
+        $this->expectException('Braintree\Exception\Configuration', 'Braintree\Configuration::merchantId needs to be set (or accessToken needs to be passed to Braintree\Gateway)');
 
         Braintree\WebhookNotification::verify('20f9f8ed05f77439fe955c977e4c8a53');
     }
@@ -83,7 +77,7 @@ class WebhookNotificationTest extends Setup
             'my_id'
         );
 
-        $this->setExpectedException('Braintree\Exception\InvalidSignature', 'signature does not match payload - one has been modified');
+        $this->expectException('Braintree\Exception\InvalidSignature', 'signature does not match payload - one has been modified');
 
         $webhookNotification = Braintree\WebhookNotification::parse(
             $sampleNotification['bt_signature'] . "bad",
@@ -91,13 +85,11 @@ class WebhookNotificationTest extends Setup
         );
     }
 
-    /**
-     * @expectedException Braintree\Exception\Configuration
-     * @expectedExceptionMessage Braintree\Configuration::merchantId needs to be set (or accessToken needs to be passed to Braintree\Gateway)
-     */
     public function testParsingWithNoKeysRaisesError()
     {
         Braintree\Configuration::reset();
+
+        $this->expectException('Braintree\Exception\Configuration', 'Braintree\Configuration::merchantId needs to be set (or accessToken needs to be passed to Braintree\Gateway)');
 
         $sampleNotification = Braintree\WebhookTesting::sampleNotification(
             Braintree\WebhookNotification::SUBSCRIPTION_WENT_PAST_DUE,
@@ -122,7 +114,7 @@ class WebhookNotificationTest extends Setup
         Braintree\Configuration::publicKey('wrong_public_key');
         Braintree\Configuration::privateKey('wrong_private_key');
 
-        $this->setExpectedException('Braintree\Exception\InvalidSignature', 'no matching public key');
+        $this->expectException('Braintree\Exception\InvalidSignature', 'no matching public key');
 
         $webhookNotification = Braintree\WebhookNotification::parse(
             $sampleNotification['bt_signature'],
@@ -137,7 +129,7 @@ class WebhookNotificationTest extends Setup
             'my_id'
         );
 
-        $this->setExpectedException('Braintree\Exception\InvalidSignature');
+        $this->expectException('Braintree\Exception\InvalidSignature');
 
         $webhookNotification = Braintree\WebhookNotification::parse(
             $sampleNotification['bt_signature'],
@@ -152,7 +144,7 @@ class WebhookNotificationTest extends Setup
             'my_id'
         );
 
-        $this->setExpectedException('Braintree\Exception\InvalidSignature');
+        $this->expectException('Braintree\Exception\InvalidSignature');
 
         $webhookNotification = Braintree\WebhookNotification::parse(
             "bad" . $sampleNotification['bt_signature'],
@@ -167,7 +159,7 @@ class WebhookNotificationTest extends Setup
             'my_id'
         );
 
-        $this->setExpectedException('Braintree\Exception\InvalidSignature');
+        $this->expectException('Braintree\Exception\InvalidSignature');
 
         $webhookNotification = Braintree\WebhookNotification::parse(
             "bad_signature",
@@ -177,14 +169,14 @@ class WebhookNotificationTest extends Setup
 
     public function testParsingNullSignatureRaisesError()
     {
-        $this->setExpectedException('Braintree\Exception\InvalidSignature', 'signature cannot be null');
+        $this->expectException('Braintree\Exception\InvalidSignature', 'signature cannot be null');
 
         $webhookNotification = Braintree\WebhookNotification::parse(null, "payload");
     }
 
     public function testParsingNullPayloadRaisesError()
     {
-        $this->setExpectedException('Braintree\Exception\InvalidSignature', 'payload cannot be null');
+        $this->expectException('Braintree\Exception\InvalidSignature', 'payload cannot be null');
 
         $webhookNotification = Braintree\WebhookNotification::parse("signature", null);
     }
@@ -196,7 +188,7 @@ class WebhookNotificationTest extends Setup
             'my_id'
         );
 
-        $this->setExpectedException('Braintree\Exception\InvalidSignature', 'payload contains illegal characters');
+        $this->expectException('Braintree\Exception\InvalidSignature', 'payload contains illegal characters');
 
         $webhookNotification = Braintree\WebhookNotification::parse(
             $sampleNotification['bt_signature'],
@@ -211,7 +203,7 @@ class WebhookNotificationTest extends Setup
             'my_id'
         );
 
-        $this->setExpectedException('Braintree\Exception\InvalidSignature', 'signature does not match payload - one has been modified');
+        $this->expectException('Braintree\Exception\InvalidSignature', 'signature does not match payload - one has been modified');
 
         $webhookNotification = Braintree\WebhookNotification::parse(
             $sampleNotification['bt_signature'],
@@ -230,6 +222,8 @@ class WebhookNotificationTest extends Setup
             $sampleNotification['bt_signature'],
             rtrim($sampleNotification['bt_payload'])
         );
+
+        $this->assertInstanceOf('Braintree\WebhookNotification', $webhookNotification);
     }
 
     public function testAllowsParsingUsingGateway()


### PR DESCRIPTION
# Summary
I understand that this cannot be merged as is because of the integration tests but hopefully it's useful as a starting point for upgrading to PHPUnit 7 which is required for PHP 7.3 compatibility.

 - Update Composer version requirements.
 - Update phpunit.xml to remove obsolete syntaxCheck and enable console colors.
 - Replace references to PHPUnit_Framework_TestCase with PHPUnit\Framework\TestCase.
 - Moved test setup routines from _construct() to setUp().
 - Replaced depreciated @expectedException and setExpectedException() with expectException().
 - Added assertNull() to seven test routines that did not return a response or assert any tests.
 - Added test for expected HTTP response code to HTTP test that did not make any assertions.