### PR TITLE
Fix typo (existance => existence)

### DIFF
--- a/lib/Braintree/Base.php
+++ b/lib/Braintree/Base.php
@@ -52,7 +52,7 @@ abstract class Base implements JsonSerializable
     }
 
     /**
-     * Checks for the existance of a property stored in the private $_attributes property
+     * Checks for the existence of a property stored in the private $_attributes property
      *
      * @ignore
      * @param string $name


### PR DESCRIPTION
# Summary
Fixed typo (existance => existence)  in comment.
