### PR TITLE
Add .gitattributes to exclude unneeded files from dist zip archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/tests export-ignore
+ci.sh export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+ACKNOWLEDGEMENTS.md export-ignore
+CHANGELOG.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,10 @@
+/.github export-ignore
 /tests export-ignore
+ACKNOWLEDGEMENTS.md export-ignore
 ci.sh export-ignore
+Dockerfile export-ignore
+Makefile export-ignore
+Rakefile export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 phpunit.xml.dist export-ignore
-ACKNOWLEDGEMENTS.md export-ignore
-CHANGELOG.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,10 @@
 /.github export-ignore
 /tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
 ACKNOWLEDGEMENTS.md export-ignore
 ci.sh export-ignore
 Dockerfile export-ignore
 Makefile export-ignore
 Rakefile export-ignore
-.gitattributes export-ignore
-.gitignore export-ignore
 phpunit.xml.dist export-ignore


### PR DESCRIPTION
# Summary

A good idea is to exclude unneeded dev files from the final production zip archive file, which is downloaded by composer (unless `--prefer -source` is specified).
Those files are only useful when working on the library itself.

If you are not familiar, further information about `export-ignore` can be found below:
- https://madewithlove.be/gitattributes/
- http://www.pixelite.co.nz/article/using-git-attributes-exclude-files-your-release/


Hope it helps

