### PR TITLE
Serialize validation errors to JSON

### DIFF
--- a/lib/Braintree/Error/ErrorCollection.php
+++ b/lib/Braintree/Error/ErrorCollection.php
@@ -2,6 +2,8 @@
 namespace Braintree\Error;
 
 use Braintree\Util;
+use Countable;
+use JsonSerializable;
 
 /**
  *
@@ -16,7 +18,7 @@ use Braintree\Util;
  *
  * @property-read object $errors
  */
-class ErrorCollection implements \Countable
+class ErrorCollection implements Countable, JsonSerializable
 {
     private $_errors;
 
@@ -118,6 +120,17 @@ class ErrorCollection implements \Countable
     public function  __toString()
     {
         return sprintf('%s', $this->_errors);
+    }
+
+    /**
+     * Implementation of JsonSerializable
+     *
+     * @ignore
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->_errors->deepAll();
     }
 }
 class_alias('Braintree\Error\ErrorCollection', 'Braintree_Error_ErrorCollection');


### PR DESCRIPTION
# Summary

While the `Result\Error` object implements the `JsonSerializable` interface, the `errors` key is currently JSON encoded as an empty object. This PR allows the `ErrorCollection` object to serialize all the validation errors as JSON.

This can be quite valuable for logging and debugging, e.g. when the `Result\Error` is passed as  context of the Monolog logger.

# Checklist

- [ ] Added changelog entry
- [ ] Ran unit tests (Check the README for instructions)
