### PR TITLE
Add support for PHP 7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.6.0
+* Add support for PHP 7.4
+
 ## 4.5.0
 * Add `PROCESSOR_DOES_NOT_SUPPORT_MOTO_FOR_CARD_TYPE` to validation errors
 * Make errors JSON serializable (#256 thanks @sebdesign)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.6.0
+## unreleased
 * Add support for PHP 7.4
 
 ## 4.5.0

--- a/lib/Braintree/Digest.php
+++ b/lib/Braintree/Digest.php
@@ -50,8 +50,8 @@ class Digest
         $outerPad = str_repeat(chr(0x5C), 64);
 
         for ($i = 0; $i < 20; $i++) {
-            $innerPad{$i} = $keyDigest{$i} ^ $innerPad{$i};
-            $outerPad{$i} = $keyDigest{$i} ^ $outerPad{$i};
+            $innerPad[$i] = $keyDigest[$i] ^ $innerPad[$i];
+            $outerPad[$i] = $keyDigest[$i] ^ $outerPad[$i];
         }
 
         return sha1($outerPad.pack($pack, sha1($innerPad.$message)));

--- a/lib/Braintree/Error/ValidationErrorCollection.php
+++ b/lib/Braintree/Error/ValidationErrorCollection.php
@@ -120,8 +120,11 @@ class ValidationErrorCollection extends Collection
     private function _inspect($errors, $scope = null)
     {
         $eOutput = '[' . __CLASS__ . '/errors:[';
+        $outputErrs = [];
         foreach($errors AS $error => $errorObj) {
-            $outputErrs[] = "({$errorObj->error['code']} {$errorObj->error['message']})";
+            if (is_array($errorObj->error)) {
+                $outputErrs[] = "({$errorObj->error['code']} {$errorObj->error['message']})";
+            }
         }
         $eOutput .= join(', ', $outputErrs) . ']]';
 


### PR DESCRIPTION
# Summary

PHP 7.4 deprecates curly brace syntax $s{0} in favour
of using regular array syntax $s[0]
    
Fix null array issue


# Checklist
- [/] Added changelog entry
- [/] Ran unit tests (Check the README for instructions)