### PR TITLE
Type for Dispute search parameter

### DIFF
--- a/lib/Braintree/DisputeGateway.php
+++ b/lib/Braintree/DisputeGateway.php
@@ -242,7 +242,7 @@ class DisputeGateway
     /**
      * Search for Disputes, given a DisputeSearch query
      *
-     * @param DisputeSearch $query
+     * @param array $query
      */
     public function search($query)
     {


### PR DESCRIPTION
# Summary
Added type for Dispute::search() parameter

# Checklist

- [ ] Added changelog entry
- [ x] Ran unit tests (Check the README for instructions)

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
