### PR TITLE
Add CreditCard properties

### DIFF
--- a/lib/Braintree/CreditCard.php
+++ b/lib/Braintree/CreditCard.php
@@ -18,6 +18,7 @@ namespace Braintree;
  * @property-read string $cardType
  * @property-read string $cardholderName
  * @property-read string $commercial
+ * @property-read string $countryOfIssuance
  * @property-read \DateTime $createdAt
  * @property-read string $customerId
  * @property-read string $customerLocation

--- a/lib/Braintree/Transaction/CreditCardDetails.php
+++ b/lib/Braintree/Transaction/CreditCardDetails.php
@@ -13,13 +13,25 @@ use Braintree\Instance;
  * @property-read string $bin
  * @property-read string $cardType
  * @property-read string $cardholderName
+ * @property-read string $commercial
+ * @property-read string $countryOfIssuance
+ * @property-read string $customerLocation
+ * @property-read string $debit
+ * @property-read string $durbinRegulated
  * @property-read string $expirationDate
  * @property-read string $expirationMonth
  * @property-read string $expirationYear
+ * @property-read string $healthcare
+ * @property-read string $imageUrl
+ * @property-read string $issuingBank
  * @property-read string $issuerLocation
  * @property-read string $last4
  * @property-read string $maskedNumber
+ * @property-read string $payroll
+ * @property-read string $prepaid
+ * @property-read string $productId
  * @property-read string $token
+ * @property-read string $uniqueNumberIdentifier
  */
 class CreditCardDetails extends Instance
 {


### PR DESCRIPTION
# Summary

By [documentation of Transaction](https://developers.braintreepayments.com/reference/response/transaction/php#credit_card_details) `CreditCardDetails` should have more properties. And it really has, so I completed list of it.
By [documentation of CreditCard](https://developers.braintreepayments.com/reference/response/credit-card/php#country_of_issuance) I also added property `CreditCard::countryOfIssuance`.

# Checklist

- [ ] Added changelog entry
- [x] Ran unit tests (Check the README for instructions)

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
