### PR TITLE
Fix documentation typo for Transaction addOns property

### DIFF
--- a/lib/Braintree/Transaction.php
+++ b/lib/Braintree/Transaction.php
@@ -141,7 +141,7 @@ namespace Braintree;
  * @category   Resources
  *
  *
- * @property-read \Braintree\AddOn[] $addons
+ * @property-read \Braintree\AddOn[] $addOns
  * @property-read string $additionalProcessorResponse raw response from processor
  * @property-read string $amount transaction amount
  * @property-read \Braintree\Transaction\AmexExpressCheckoutCardDetails $amexExpressCheckoutCardDetails DEPRECATED transaction Amex Express Checkout card info.


### PR DESCRIPTION
# Summary

The property documentation for `Transaction::addOns` was incorrectly cased. This fixes the casing of the documentation to match the casing of the attribute.

Fixes #285 

# Checklist

- [ ] Added changelog entry
- [x] Ran unit tests (Check the README for instructions)
