### PR TITLE
Base & Instance __isset fixed, unit tests updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.0.1
+* Fix __isset methods for Instance and Base classes
+
 ## 6.0.0
 * Add `LocalPaymentReversed` webhook
 * Add `adjustAuthorization` method to Transaction, for supporting multiple authorizations on a single transaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 6.0.1
-* Fix __isset methods for Instance and Base classes
+* Fix bug where `__isset` methods in `Instance` and `Base` classes treated `null` value as set
 
 ## 6.0.0
 * Add `LocalPaymentReversed` webhook

--- a/lib/Braintree/Base.php
+++ b/lib/Braintree/Base.php
@@ -62,7 +62,7 @@ abstract class Base implements JsonSerializable
      */
     public function __isset($name)
     {
-        return array_key_exists($name, $this->_attributes);
+        return isset($this->_attributes[$name]);
     }
 
     /**

--- a/lib/Braintree/Instance.php
+++ b/lib/Braintree/Instance.php
@@ -45,7 +45,7 @@ abstract class Instance
      */
     public function __isset($name)
     {
-        return array_key_exists($name, $this->_attributes);
+        return isset($this->_attributes[$name]);
     }
 
     /**

--- a/tests/unit/BaseTest.php
+++ b/tests/unit/BaseTest.php
@@ -84,5 +84,48 @@ class BaseTest extends Setup
         'channel' => 'sonic',
       ]);
       $this->assertTrue(isset($transaction->channel));
+      $this->assertFalse(empty($transaction->channel));
+
+
+      $transaction = Braintree\Transaction::factory([
+        'creditCard' => [
+          'expirationMonth' => '05',
+          'expirationYear' => '2010',
+          'bin' => '510510',
+          'last4' => '5100',
+          'cardType' => 'MasterCard',
+        ],
+        'channel' => false,
+      ]);
+      $this->assertTrue(isset($transaction->channel));
+      $this->assertTrue(empty($transaction->channel));
+
+
+      $transaction = Braintree\Transaction::factory([
+        'creditCard' => [
+          'expirationMonth' => '05',
+          'expirationYear' => '2010',
+          'bin' => '510510',
+          'last4' => '5100',
+          'cardType' => 'MasterCard',
+        ],
+        'channel' => null,
+      ]);
+      $this->assertFalse(isset($transaction->channel));
+      $this->assertTrue(empty($transaction->channel));
+
+
+      $transaction = Braintree\Transaction::factory([
+        'creditCard' => [
+          'expirationMonth' => '05',
+          'expirationYear' => '2010',
+          'bin' => '510510',
+          'last4' => '5100',
+          'cardType' => 'MasterCard',
+        ],
+      ]);
+      $this->assertFalse(isset($transaction->channel));
+      $this->assertTrue(empty($transaction->channel));
+
     }
 }

--- a/tests/unit/BaseTest.php
+++ b/tests/unit/BaseTest.php
@@ -71,7 +71,7 @@ class BaseTest extends Setup
       $this->assertEquals('Braintree\Transaction[id=foo, type=sale, amount=10.00, status=authorized, createdAt=1/1/11, creditCardDetails=Braintree\Transaction\CreditCardDetails[expirationMonth=05, expirationYear=2010, bin=510510, last4=5100, cardType=MasterCard, expirationDate=05/2010, maskedNumber=510510******5100], customerDetails=Braintree\Transaction\CustomerDetails[id=bar]]', $stringified);
     }
 
-    public function test__isset()
+    public function test__isset_whenSetReturnsTrue()
     {
       $transaction = Braintree\Transaction::factory([
         'creditCard' => [
@@ -86,7 +86,6 @@ class BaseTest extends Setup
       $this->assertTrue(isset($transaction->channel));
       $this->assertFalse(empty($transaction->channel));
 
-
       $transaction = Braintree\Transaction::factory([
         'creditCard' => [
           'expirationMonth' => '05',
@@ -99,8 +98,10 @@ class BaseTest extends Setup
       ]);
       $this->assertTrue(isset($transaction->channel));
       $this->assertTrue(empty($transaction->channel));
+    }
 
-
+    public function test__isset_whenSetToNullReturnsFalse()
+    {
       $transaction = Braintree\Transaction::factory([
         'creditCard' => [
           'expirationMonth' => '05',
@@ -113,8 +114,10 @@ class BaseTest extends Setup
       ]);
       $this->assertFalse(isset($transaction->channel));
       $this->assertTrue(empty($transaction->channel));
+    }
 
-
+    public function test__isset_whenNotSetReturnsFalse()
+    {
       $transaction = Braintree\Transaction::factory([
         'creditCard' => [
           'expirationMonth' => '05',
@@ -126,6 +129,5 @@ class BaseTest extends Setup
       ]);
       $this->assertFalse(isset($transaction->channel));
       $this->assertTrue(empty($transaction->channel));
-
     }
 }

--- a/tests/unit/InstanceTest.php
+++ b/tests/unit/InstanceTest.php
@@ -33,6 +33,30 @@ class InstanceTest extends Setup
       ]);
       $this->assertTrue(empty($transaction->creditCardDetails->cardType));
       $this->assertFalse(isset($transaction->creditCardDetails->cardType));
+
+      $transaction = Braintree\Transaction::factory([
+        'creditCard' => [
+          'expirationMonth' => '05',
+          'expirationYear' => '2010',
+          'bin' => '510510',
+          'last4' => '5100',
+          'cardType' => null,
+        ],
+      ]);
+      $this->assertTrue(empty($transaction->creditCardDetails->cardType));
+      $this->assertFalse(isset($transaction->creditCardDetails->cardType));
+
+      $transaction = Braintree\Transaction::factory([
+        'creditCard' => [
+          'expirationMonth' => '05',
+          'expirationYear' => '2010',
+          'bin' => '510510',
+          'last4' => '5100',
+          'cardType' => false,
+        ],
+      ]);
+      $this->assertTrue(empty($transaction->creditCardDetails->cardType));
+      $this->assertTrue(isset($transaction->creditCardDetails->cardType));
     }
 
     public function testToArray()

--- a/tests/unit/InstanceTest.php
+++ b/tests/unit/InstanceTest.php
@@ -8,7 +8,7 @@ use Braintree;
 
 class InstanceTest extends Setup
 {
-    public function test__isset()
+    public function test__isset_whenSetReturnsTrue()
     {
       $transaction = Braintree\Transaction::factory([
         'creditCard' => [
@@ -22,30 +22,7 @@ class InstanceTest extends Setup
       $this->assertEquals('MasterCard', $transaction->creditCardDetails->cardType);
       $this->assertFalse(empty($transaction->creditCardDetails->cardType));
       $this->assertTrue(isset($transaction->creditCardDetails->cardType));
-
-      $transaction = Braintree\Transaction::factory([
-        'creditCard' => [
-          'expirationMonth' => '05',
-          'expirationYear' => '2010',
-          'bin' => '510510',
-          'last4' => '5100',
-        ],
-      ]);
-      $this->assertTrue(empty($transaction->creditCardDetails->cardType));
-      $this->assertFalse(isset($transaction->creditCardDetails->cardType));
-
-      $transaction = Braintree\Transaction::factory([
-        'creditCard' => [
-          'expirationMonth' => '05',
-          'expirationYear' => '2010',
-          'bin' => '510510',
-          'last4' => '5100',
-          'cardType' => null,
-        ],
-      ]);
-      $this->assertTrue(empty($transaction->creditCardDetails->cardType));
-      $this->assertFalse(isset($transaction->creditCardDetails->cardType));
-
+    
       $transaction = Braintree\Transaction::factory([
         'creditCard' => [
           'expirationMonth' => '05',
@@ -57,6 +34,35 @@ class InstanceTest extends Setup
       ]);
       $this->assertTrue(empty($transaction->creditCardDetails->cardType));
       $this->assertTrue(isset($transaction->creditCardDetails->cardType));
+    }
+
+    public function test__isset_whenNotSetReturnsFalse()
+    {
+      $transaction = Braintree\Transaction::factory([
+        'creditCard' => [
+          'expirationMonth' => '05',
+          'expirationYear' => '2010',
+          'bin' => '510510',
+          'last4' => '5100',
+        ],
+      ]);
+      $this->assertTrue(empty($transaction->creditCardDetails->cardType));
+      $this->assertFalse(isset($transaction->creditCardDetails->cardType));
+    }
+
+    public function test__isset_whenSetToNullReturnsFalse()
+    {
+      $transaction = Braintree\Transaction::factory([
+        'creditCard' => [
+          'expirationMonth' => '05',
+          'expirationYear' => '2010',
+          'bin' => '510510',
+          'last4' => '5100',
+          'cardType' => null,
+        ],
+      ]);
+      $this->assertTrue(empty($transaction->creditCardDetails->cardType));
+      $this->assertFalse(isset($transaction->creditCardDetails->cardType));
     }
 
     public function testToArray()


### PR DESCRIPTION
# Summary

Broken __isset method caused null values treated as set. For example: isset($transaction->creditCardDetails->customerLocation) => true even when customerLocation was null.

# Checklist

- Added changelog entry
- Ran unit tests (Check the README for instructions)