### PR TITLE
Add more subscription xml samples for test cases

### DIFF
--- a/lib/Braintree/WebhookTestingGateway.php
+++ b/lib/Braintree/WebhookTestingGateway.php
@@ -89,13 +89,13 @@ class WebhookTestingGateway
                 $subjectXml = self::_subscriptionChargedUnsuccessfullySampleXml($id);
                 break;
             case WebhookNotification::SUBSCRIPTION_EXPIRED:
-                $subjectXml = self::_subscriptionExpired($id);
+                $subjectXml = self::_subscriptionExpiredSampleXml($id);
                 break;
             case WebhookNotification::SUBSCRIPTION_CANCELED:
-                $subjectXml = self::_subscriptionCanceled($id);
+                $subjectXml = self::_subscriptionCanceledSampleXml($id);
                 break;
             case WebhookNotification::SUBSCRIPTION_WENT_PAST_DUE:
-                $subjectXml = self::_subscriptionWentPastDue($id);
+                $subjectXml = self::_subscriptionWentPastDueSampleXml($id);
                 break;
             case WebhookNotification::CHECK:
                 $subjectXml = self::_checkSampleXml();

--- a/lib/Braintree/WebhookTestingGateway.php
+++ b/lib/Braintree/WebhookTestingGateway.php
@@ -88,6 +88,15 @@ class WebhookTestingGateway
             case WebhookNotification::SUBSCRIPTION_CHARGED_UNSUCCESSFULLY:
                 $subjectXml = self::_subscriptionChargedUnsuccessfullySampleXml($id);
                 break;
+            case WebhookNotification::SUBSCRIPTION_EXPIRED:
+                $subjectXml = self::_subscriptionExpired($id);
+                break;
+            case WebhookNotification::SUBSCRIPTION_CANCELED:
+                $subjectXml = self::_subscriptionCanceled($id);
+                break;
+            case WebhookNotification::SUBSCRIPTION_WENT_PAST_DUE:
+                $subjectXml = self::_subscriptionWentPastDue($id);
+                break;
             case WebhookNotification::CHECK:
                 $subjectXml = self::_checkSampleXml();
                 break;
@@ -423,6 +432,7 @@ class WebhookTestingGateway
         return "
         <subscription>
             <id>{$id}</id>
+            <status>Active</status>
             <transactions type=\"array\">
             </transactions>
             <add_ons type=\"array\">
@@ -438,6 +448,7 @@ class WebhookTestingGateway
         return "
         <subscription>
             <id>{$id}</id>
+            <status>Active</status>
             <billing-period-start-date type=\"date\">2016-03-21</billing-period-start-date>
             <billing-period-end-date type=\"date\">2017-03-31</billing-period-end-date>
             <transactions type=\"array\">
@@ -460,6 +471,7 @@ class WebhookTestingGateway
         return "
         <subscription>
             <id>{$id}</id>
+            <status>Active</status>
             <billing-period-start-date type=\"date\">2016-03-21</billing-period-start-date>
             <billing-period-end-date type=\"date\">2017-03-31</billing-period-end-date>
             <transactions type=\"array\">
@@ -468,6 +480,51 @@ class WebhookTestingGateway
                     <status>failed</status>
                     <amount>49.99</amount>
                 </transaction>
+            </transactions>
+            <add_ons type=\"array\">
+            </add_ons>
+            <discounts type=\"array\">
+            </discounts>
+        </subscription>
+        ";
+    }
+
+    private static function _subscriptionExpired($id) {
+        return "
+        <subscription>
+            <id>{$id}</id>
+            <status>Expired</status>
+            <transactions type=\"array\">
+            </transactions>
+            <add_ons type=\"array\">
+            </add_ons>
+            <discounts type=\"array\">
+            </discounts>
+        </subscription>
+        ";
+    }
+
+    private static function _subscriptionCanceled($id) {
+        return "
+        <subscription>
+            <id>{$id}</id>
+            <status>Canceled</status>
+            <transactions type=\"array\">
+            </transactions>
+            <add_ons type=\"array\">
+            </add_ons>
+            <discounts type=\"array\">
+            </discounts>
+        </subscription>
+        ";
+    }
+
+    private static function _subscriptionWentPastDue($id) {
+        return "
+        <subscription>
+            <id>{$id}</id>
+            <status>Past Due</status>
+            <transactions type=\"array\">
             </transactions>
             <add_ons type=\"array\">
             </add_ons>

--- a/lib/Braintree/WebhookTestingGateway.php
+++ b/lib/Braintree/WebhookTestingGateway.php
@@ -489,7 +489,7 @@ class WebhookTestingGateway
         ";
     }
 
-    private static function _subscriptionExpired($id) {
+    private static function _subscriptionExpiredSampleXml($id) {
         return "
         <subscription>
             <id>{$id}</id>
@@ -504,7 +504,7 @@ class WebhookTestingGateway
         ";
     }
 
-    private static function _subscriptionCanceled($id) {
+    private static function _subscriptionCanceledSampleXml($id) {
         return "
         <subscription>
             <id>{$id}</id>
@@ -519,7 +519,7 @@ class WebhookTestingGateway
         ";
     }
 
-    private static function _subscriptionWentPastDue($id) {
+    private static function _subscriptionWentPastDueSampleXml($id) {
         return "
         <subscription>
             <id>{$id}</id>


### PR DESCRIPTION
# Summary
Hi 
I make unit tests using ```WebhookTestingGateway::sampleNotification``` function and I found that the subscription object didn`t have status property so I added it because for me this property is very important  and I olso added samples xml for types:
- SUBSCRIPTION_CANCELED
- SUBSCRIPTION_EXPIRED
- SUBSCRIPTION_WENT_PAST_DUE

If these changes do not suit for you, explain how to test this types of notification without it ?

# Checklist

- [ ] Added changelog entry
- [x] Ran unit tests (Check the README for instructions)


