### PR TITLE
Update Util.php

### DIFF
--- a/lib/Braintree/Util.php
+++ b/lib/Braintree/Util.php
@@ -226,7 +226,7 @@ class Util
         static $callback = null;
         if ($callback === null) {
             $callback = function ($matches) {
-                return strtoupper($matches[1]);
+                return mb_strtoupper($matches[1]);
             };
         }
 
@@ -256,7 +256,7 @@ class Util
      */
     public static function camelCaseToDelimiter($string, $delimiter = '-')
     {
-        return strtolower(preg_replace('/([A-Z])/', "$delimiter\\1", $string));
+        return mb_strtolower(preg_replace('/([A-Z])/', "$delimiter\\1", $string));
     }
 
     public static function delimiterToCamelCaseArray($array, $delimiter = '[\-\_]')


### PR DESCRIPTION
Converting the calls of strtolower an strtoupper to their multibyte equivalents supports languages with multibyte characters such as Turkish.

# Summary

# Checklist

- [/] Added changelog entry
- [/] Ran unit tests (Check the README for instructions)

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
