### PR TITLE
Add multibyte character support to Util.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.2.1
+* Add multibyte character support to `Util` functions
+
 ## 6.2.0
 * Add `chargebackProtectionLevel ` to `Dispute` and `DisputeSearch`
 * Add `skipAdvancedFraudChecking` to: 

--- a/lib/Braintree/Util.php
+++ b/lib/Braintree/Util.php
@@ -226,7 +226,7 @@ class Util
         static $callback = null;
         if ($callback === null) {
             $callback = function ($matches) {
-                return strtoupper($matches[1]);
+                return extension_loaded('mbstring') ? mb_strtoupper($matches[1]) : strtoupper($matches[1]);
             };
         }
 
@@ -256,7 +256,9 @@ class Util
      */
     public static function camelCaseToDelimiter($string, $delimiter = '-')
     {
-        return strtolower(preg_replace('/([A-Z])/', "$delimiter\\1", $string));
+        return extension_loaded('mbstring') ?
+            mb_strtolower(preg_replace('/([A-Z])/', "$delimiter\\1", $string)) :
+            strtolower(preg_replace('/([A-Z])/', "$delimiter\\1", $string));
     }
 
     public static function delimiterToCamelCaseArray($array, $delimiter = '[\-\_]')


### PR DESCRIPTION
# Summary

Check if the mbstring extension is loaded, if so use the multibyte versions of strtoupper and strtolower. Fixes issues with Dropin UI when using Turkish language.

# Checklist

- [/] Added changelog entry
- [/] Ran unit tests (Check the README for instructions)

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
