### PR TITLE
Fix bug where method_exists() may be called on a null value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## Unreleased
+* Fix bug where `method_exists` checks might be performed on null values
+
 ## 6.8.0
 * Add `retried` to `Transaction`
 

--- a/lib/Braintree/Base.php
+++ b/lib/Braintree/Base.php
@@ -94,7 +94,7 @@ abstract class Base implements JsonSerializable
     {
         return array_map(function ($value) {
             if (!is_array($value)) {
-                return method_exists($value, 'toArray') ? $value->toArray() : $value;
+                return is_object($value) && method_exists($value, 'toArray') ? $value->toArray() : $value;
             } else {
                 return $value;
             }

--- a/lib/Braintree/Instance.php
+++ b/lib/Braintree/Instance.php
@@ -90,7 +90,7 @@ abstract class Instance
     {
         return array_map(function ($value) {
             if (!is_array($value)) {
-                return method_exists($value, 'toArray') ? $value->toArray() : $value;
+                return is_object($value) && method_exists($value, 'toArray') ? $value->toArray() : $value;
             } else {
                 return $value;
             }


### PR DESCRIPTION
# Summary

Braintree SDK: 6.5.0
PHP: 8.0.5

When `->toArray()` is called on Braintree responses, it sometimes throws a type error when treating null as an object:

```
method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given
```

# Checklist

- [x] Added changelog entry
- [x] Ran unit tests (Check the README for instructions)

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
