### PR TITLE
Bugfix/serializable validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 6.5.2
+* Make Error\Validation jsonSerializable
 ## 6.5.1
 * Address PHP 8.1 Deprecation warnings
 

--- a/lib/Braintree/Error/Validation.php
+++ b/lib/Braintree/Error/Validation.php
@@ -3,6 +3,7 @@
 namespace Braintree\Error;
 
 use Braintree\Util;
+use JsonSerializable;
 
 /**
  * error object returned as part of a validation error collection
@@ -13,7 +14,7 @@ use Braintree\Util;
  * // phpcs:ignore Generic.Files.LineLength
  * See our {@link https://developer.paypal.com/braintree/docs/reference/general/result-objects#error-results developer docs} for more information
  */
-class Validation
+class Validation implements JsonSerializable
 {
     private $_attribute;
     private $_code;
@@ -39,5 +40,19 @@ class Validation
     {
         $varName = "_$name";
         return isset($this->$varName) ? $this->$varName : null;
+    }
+
+        /**
+     * Implementation of JsonSerializable
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return array(
+                    'code' => $this->__get('code'),
+                    'attribute' => $this->__get('attribute'),
+                    'message' => $this->__get('message')
+                );
     }
 }


### PR DESCRIPTION
# Summary

# Checklist

- [* ] Added changelog entry
- [x ] Ran unit tests (Check the README for instructions)
```root@docker-desktop:/braintree-php# rake test:unit
php ./vendor/bin/phpcs --config-set show_progress 1
Using config file: /braintree-php/vendor/squizlabs/php_codesniffer/CodeSniffer.conf

Config value "show_progress" added successfully
php ./vendor/bin/phpcs --config-set colors 1
Using config file: /braintree-php/vendor/squizlabs/php_codesniffer/CodeSniffer.conf

Config value "colors" added successfully
php ./vendor/bin/phpcs --config-set php_version 70300
Using config file: /braintree-php/vendor/squizlabs/php_codesniffer/CodeSniffer.conf

Config value "php_version" added successfully
php ./vendor/bin/phpcs --standard=phpcs.xml --report=summary -s lib tests
............................................................  60 / 279 (22%)
............................................................ 120 / 279 (43%)
............................................................ 180 / 279 (65%)
............................................................ 240 / 279 (86%)
.......................................                      279 / 279 (100%)


Time: 4.52 secs; Memory: 66.01MB

php ./vendor/bin/phpunit --testsuite unit --do-not-cache-result
PHPUnit 9.5.13 by Sebastian Bergmann and contributors.

...............................................................  63 / 360 ( 17%)
............................................................... 126 / 360 ( 35%)
........................................................PHP Deprecated:  Return type of Braintree\Error\Validation::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /braintree-php/lib/Braintree/Error/Validation.php on line 50
....... 189 / 360 ( 52%)
............................................................... 252 / 360 ( 70%)
............................................................... 315 / 360 ( 87%)
.............................................                   360 / 360 (100%)

Time: 00:00.372, Memory: 12.00 MB

OK (360 tests, 1077 assertions)
```

- [x ] I understand that unless this is a Draft PR or has a DO NOT MERGE label, this PR is considered to be in a deploy ready state and can be deployed if merged to main

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
