### PR TITLE
Fix namespace in docblock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.7.1
+* Fix wrong namespacing for the `Braintree\Result\ERror` class on docblocks
+
 ## 6.7.0
 * Fix lint errors on unit test
 

--- a/lib/Braintree/PaymentMethodNonce.php
+++ b/lib/Braintree/PaymentMethodNonce.php
@@ -21,7 +21,7 @@ class PaymentMethodNonce extends Base
      *
      * @see PaymentMethodNonceGateway::create()
      *
-     * @return PaymentMethodNonce|Error
+     * @return PaymentMethodNonce|Result\Error
      */
     public static function create($token, $params = [])
     {

--- a/lib/Braintree/PaymentMethodNonceGateway.php
+++ b/lib/Braintree/PaymentMethodNonceGateway.php
@@ -25,7 +25,7 @@ class PaymentMethodNonceGateway
      * @param string     $token  the identifier of the payment method
      * @param mixed|null $params additional parameters to be included in the request
      *
-     * @return PaymentMethodNonce|Error
+     * @return PaymentMethodNonce|Result\Error
      */
     public function create($token, $params = [])
     {

--- a/lib/Braintree/UsBankAccount.php
+++ b/lib/Braintree/UsBankAccount.php
@@ -78,7 +78,7 @@ class UsBankAccount extends Base
      *
      * @see USBankAccountGateway::find()
      *
-     * @return UsBankAccount|Error
+     * @return UsBankAccount|Result\Error
      */
     public static function find($token)
     {
@@ -91,7 +91,7 @@ class UsBankAccount extends Base
      * @param string $token              the payment method identifier
      * @param array  $transactionAttribs all other transaction parameters
      *
-     * @return UsBankAccount|Error
+     * @return UsBankAccount|Result\Error
      */
     public static function sale($token, $transactionAttribs)
     {


### PR DESCRIPTION
# Summary
The Error class wasn't namespaced properly everywhere. The few
classes in this MR were referencing a non-existing class
(`Braintree\Error`).

This MR aims to fix the namespace so static analysis tools do not
fail while looking for the non-existing class.

# Checklist

- [x] Added changelog entry
- [x] Ran unit tests (Check the README for instructions)
- [x] I understand that unless this is a Draft PR or has a DO NOT MERGE label, this PR is considered to be in a deploy ready state and can be deployed if merged to main
