### PR TITLE
Fixes Docblock class ClientTokenGateway

### DIFF
--- a/lib/Braintree/ClientTokenGateway.php
+++ b/lib/Braintree/ClientTokenGateway.php
@@ -28,7 +28,7 @@ class ClientTokenGateway
     /**
      * Generate a client token for client-side authorization
      *
-     * @param Optional $params containing request parameters
+     * @param $params Optional, containing request parameters
      *
      * @return string client token
      */

--- a/lib/Braintree/PayPalAccountGateway.php
+++ b/lib/Braintree/PayPalAccountGateway.php
@@ -153,7 +153,7 @@ class PayPalAccountGateway
      * verifies that a valid paypal account identifier is being used
      *
      * @param string   $identifier
-     * @param Optional $string     $identifierType type of identifier supplied, default 'token'
+     * @param string   $identifierType Optional, type of identifier supplied, default 'token'
      *
      * @throws InvalidArgumentException
      */


### PR DESCRIPTION
Fixes format  in Docblock classes: ClientTokenGateway and PayPalAccountGateway

Actual Docblock, cause an error for static analysis like Psalm, Phpstan because the class Optional does not exist actually 