### PR TITLE
[PHP 8.2] Fix `${var}` string interpolation deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 6.9.0
+* Address PHP 8.2 deprecation warnings due to string interpolation patterns.
+
 ## 6.8.0
 * Add `retried` to `Transaction`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 * Add support for `ExchangeRateQuoteAPI`
 * Fix various PHP 8.1 `null` warnings (thanks @simoheinonen & @robbieaverill)
 
-
 ## 6.8.0
 * Add `retried` to `Transaction`
 

--- a/lib/Braintree/WebhookTestingGateway.php
+++ b/lib/Braintree/WebhookTestingGateway.php
@@ -217,7 +217,7 @@ class WebhookTestingGateway
     {
         return "
         <transaction>
-            <id>${id}</id>
+            <id>{$id}</id>
             <amount>100</amount>
             <disbursement-details>
                 <disbursement-date type=\"date\">2013-07-09</disbursement-date>
@@ -243,7 +243,7 @@ class WebhookTestingGateway
     {
         return "
         <transaction>
-          <id>${id}</id>
+          <id>{$id}</id>
           <status>settled</status>
           <type>sale</type>
           <currency-iso-code>USD</currency-iso-code>
@@ -264,7 +264,7 @@ class WebhookTestingGateway
     {
         return "
         <transaction>
-          <id>${id}</id>
+          <id>{$id}</id>
           <status>settlement_declined</status>
           <type>sale</type>
           <currency-iso-code>USD</currency-iso-code>
@@ -285,7 +285,7 @@ class WebhookTestingGateway
     {
         return "
         <disbursement>
-          <id>${id}</id>
+          <id>{$id}</id>
           <transaction-ids type=\"array\">
             <item>asdfg</item>
             <item>qwert</item>
@@ -310,7 +310,7 @@ class WebhookTestingGateway
     {
         return "
         <disbursement>
-          <id>${id}</id>
+          <id>{$id}</id>
           <transaction-ids type=\"array\">
             <item>asdfg</item>
             <item>qwert</item>
@@ -344,9 +344,9 @@ class WebhookTestingGateway
           <kind>chargeback</kind>
           <status>open</status>
           <reason>fraud</reason>
-          <id>${id}</id>
+          <id>{$id}</id>
           <transaction>
-            <id>${id}</id>
+            <id>{$id}</id>
             <amount>250.00</amount>
           </transaction>
           <date-opened type=\"date\">2014-03-21</date-opened>
@@ -367,9 +367,9 @@ class WebhookTestingGateway
           <kind>chargeback</kind>
           <status>lost</status>
           <reason>fraud</reason>
-          <id>${id}</id>
+          <id>{$id}</id>
           <transaction>
-            <id>${id}</id>
+            <id>{$id}</id>
             <amount>250.00</amount>
             <next_billing-date type=\"date\">2020-02-10</next_billing-date>
           </transaction>
@@ -391,9 +391,9 @@ class WebhookTestingGateway
           <kind>chargeback</kind>
           <status>won</status>
           <reason>fraud</reason>
-          <id>${id}</id>
+          <id>{$id}</id>
           <transaction>
-            <id>${id}</id>
+            <id>{$id}</id>
             <amount>250.00</amount>
           </transaction>
           <date-opened type=\"date\">2014-03-21</date-opened>
@@ -415,9 +415,9 @@ class WebhookTestingGateway
           <kind>chargeback</kind>
           <status>accepted</status>
           <reason>fraud</reason>
-          <id>${id}</id>
+          <id>{$id}</id>
           <transaction>
-            <id>${id}</id>
+            <id>{$id}</id>
             <amount>250.00</amount>
           </transaction>
           <date-opened type=\"date\">2014-03-21</date-opened>
@@ -438,9 +438,9 @@ class WebhookTestingGateway
           <kind>chargeback</kind>
           <status>disputed</status>
           <reason>fraud</reason>
-          <id>${id}</id>
+          <id>{$id}</id>
           <transaction>
-            <id>${id}</id>
+            <id>{$id}</id>
             <amount>250.00</amount>
           </transaction>
           <date-opened type=\"date\">2014-03-21</date-opened>
@@ -461,9 +461,9 @@ class WebhookTestingGateway
           <kind>chargeback</kind>
           <status>expired</status>
           <reason>fraud</reason>
-          <id>${id}</id>
+          <id>{$id}</id>
           <transaction>
-            <id>${id}</id>
+            <id>{$id}</id>
             <amount>250.00</amount>
           </transaction>
           <date-opened type=\"date\">2014-03-21</date-opened>


### PR DESCRIPTION
# Summary
PHP 8.2 deprecates `"${var}"` string interpolation pattern.
This fixes all three of such occurrences in `braintree/braintree_php` package.

 - [PHP 8.2: `${var}` string interpolation deprecated](https://php.watch/versions/8.2/${var}-string-interpolation-deprecated)
 - [RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)

# Checklist

- [x] Added changelog entry
- [x] Ran unit tests (Check the README for instructions)
- [x] I understand that unless this is a Draft PR or has a DO NOT MERGE label, this PR is considered to be in a deploy ready state and can be deployed if merged to main

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
