### PR TITLE
PHP 8.2 Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.11.0
+* Address PHP 8.2 deprecation warnings for dynamic properties usage.
+
 ## 6.10.0
 * Add `SEPADirectDebitAccount` payment method
 * Add `SEPADirectDebitAccountDetails` to transaction object

--- a/lib/Braintree/GraphQLClient.php
+++ b/lib/Braintree/GraphQLClient.php
@@ -8,6 +8,8 @@ namespace Braintree;
  */
 class GraphQLClient
 {
+    protected $_service = null;
+
     // phpcs:ignore PEAR.Commenting.FunctionComment.Missing
     public function __construct($config)
     {

--- a/lib/Braintree/Instance.php
+++ b/lib/Braintree/Instance.php
@@ -7,7 +7,7 @@ namespace Braintree;
  *
  * @abstract
  */
-abstract class Instance
+abstract class Instance extends \stdClass
 {
     protected $_attributes = [];
 

--- a/lib/Braintree/IsNode.php
+++ b/lib/Braintree/IsNode.php
@@ -8,6 +8,9 @@ namespace Braintree;
  */
 class IsNode
 {
+    public $name;
+    public $searchTerms;
+
     // phpcs:ignore PEAR.Commenting.FunctionComment.Missing
     public function __construct($name)
     {

--- a/lib/Braintree/MultipleValueNode.php
+++ b/lib/Braintree/MultipleValueNode.php
@@ -10,6 +10,10 @@ use InvalidArgumentException;
  */
 class MultipleValueNode
 {
+    private $name;
+    private $items;
+    private $allowedValues;
+
     // phpcs:ignore PEAR.Commenting.FunctionComment.Missing
     public function __construct($name, $allowedValues = [])
     {


### PR DESCRIPTION
# Summary

These changes intend to fix a number of deprecation warnings encountered when using the library under PHP 8.2 e.g. `Creation of dynamic property Braintree\\Result\\Successful::$transaction is deprecated`

Where possible the properties have simply been added to the classes. However in the case of `Instance` this was not possible and it does require the use of dynamic properties currently. So a workaround of extending `stdClass` has been used see https://php.watch/versions/8.2/dynamic-properties-deprecated#stdClass for more details. 

# Checklist

- [x] Added changelog entry
- [x] Ran unit tests (Check the README for instructions)
- [x] I understand that unless this is a Draft PR or has a DO NOT MERGE label, this PR is considered to be in a deploy ready state and can be deployed if merged to main

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
