### PR TITLE
Update TransactionGateway.php

### DIFF
--- a/lib/Braintree/TransactionGateway.php
+++ b/lib/Braintree/TransactionGateway.php
@@ -399,7 +399,9 @@ class TransactionGateway
      *
      * @param string $id unique identifier of the transaction
      *
-     * @return Transaction|Exception\NotFound
+     * @return Transaction
+     *
+     * @throws Exception\NotFound
      */
     public function find($id)
     {
@@ -453,6 +455,8 @@ class TransactionGateway
      * @param mixed $query search query
      *
      * @return ResourceCollection
+     *
+     * @throws Exception\RequestTimeout
      */
     public function search($query)
     {
@@ -483,6 +487,8 @@ class TransactionGateway
      * @param array $ids   to use in searching
      *
      * @return array
+     *
+     * @throws Exception\RequestTimeout
      */
     public function fetch($query, $ids)
     {
@@ -542,7 +548,9 @@ class TransactionGateway
      *
      * @param string $transactionId unique identifier
      *
-     * @return Transaction|Result\Error
+     * @return Transaction
+     *
+     * @throws Exception
      */
     public function voidNoValidate($transactionId)
     {
@@ -577,7 +585,9 @@ class TransactionGateway
      * @param string|null $amount        to be submitted for settlement
      * @param array       $attribs       containing any additional request parameters
      *
-     * @return Transaction|Exception
+     * @return Transaction
+     *
+     * @throws Exception
      */
     public function submitForSettlementNoValidate($transactionId, $amount = null, $attribs = [])
     {
@@ -610,7 +620,9 @@ class TransactionGateway
      * @param string $amount        optional
      * @param mixed  $attribs       any additional request parameters
      *
-     * @return Result\Successful|Exception\NotFound
+     * @return Result\Successful|Result\Error
+     *
+     * @throws Exception
      */
     public function submitForPartialSettlement($transactionId, $amount, $attribs = [])
     {


### PR DESCRIPTION
The braintree php library is fairly frustrating to use from a typehint/phpdoc standpoint.
The phpdocs are often times just plain wrong.

Just some examples of bad phpdoc:
Not using @throws, putting the @throws into the return (crazy lol). If the method could throw many/multiple things, I left as `@throws Exception` as a generic, but if desired you could go deeper

I'm not sure in braintree is working on a new version that will supersede all of this, so I don't want to take the time to audit everything, but I at least wanted to call it to your attention and see what thoughts you had.

Thanks.