### PR TITLE
Bug: Instance must implement JsonSerializable

### DIFF
--- a/lib/Braintree/Instance.php
+++ b/lib/Braintree/Instance.php
@@ -2,12 +2,14 @@
 
 namespace Braintree;
 
+use JsonSerializable;
+
 /**
  * Braintree Class Instance template
  *
  * @abstract
  */
-abstract class Instance extends \stdClass
+abstract class Instance extends \stdClass implements JsonSerializable
 {
     protected $_attributes = [];
 


### PR DESCRIPTION
If the interface is not implemented the jsonSerialize is never called

# Summary

# Checklist

- [ ] Added changelog entry
- [ ] Ran unit tests (Check the README for instructions)
- [ ] I understand that unless this is a Draft PR or has a DO NOT MERGE label, this PR is considered to be in a deploy ready state and can be deployed if merged to main

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
