### PR TITLE
Close curl only on PHP < 8.0

### DIFF
--- a/lib/Braintree/HttpHelpers/CurlRequest.php
+++ b/lib/Braintree/HttpHelpers/CurlRequest.php
@@ -46,6 +46,8 @@ class CurlRequest implements HttpRequest
     // phpcs:ignore PEAR.Commenting.FunctionComment.Missing
     public function close()
     {
-        curl_close($this->_handle);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($this->_handle);
+        }
     }
 }


### PR DESCRIPTION
# Summary
curl_close has only an effect below [PHP 8.0.0](https://www.php.net/manual/en/function.curl-close.php). 
